### PR TITLE
Add controlled product documentation promotion

### DIFF
--- a/.github/workflows/product-docs.yml
+++ b/.github/workflows/product-docs.yml
@@ -1,0 +1,103 @@
+name: Product documentation promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full 40-character SHA of the current dev head
+        required: true
+        type: string
+      release_version:
+        description: Release version to promote, for example v2.0.0
+        required: true
+        default: v2.0.0
+        type: string
+      release_branch:
+        description: New generated branch name
+        required: true
+        default: release/v2.0.0
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: product-docs-promotion-${{ inputs.release_branch }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Generate reviewed main promotion
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the requested dev source
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Verify dev has not moved
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'
+          git fetch origin refs/heads/dev:refs/remotes/origin/dev
+          test "$(git rev-parse refs/remotes/origin/dev)" = "$SOURCE_SHA" || {
+            echo "dev moved; restart promotion with its new exact head SHA" >&2
+            exit 1
+          }
+          git checkout --detach "$SOURCE_SHA"
+          python3 scripts/promote-product-docs.py --check-source
+
+      - name: Create the release branch and materialize main docs
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+        run: |
+          printf '%s' "$RELEASE_VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$'
+          printf '%s' "$RELEASE_BRANCH" | grep -Eq '^release/[A-Za-z0-9._/-]+$'
+          git switch -c "$RELEASE_BRANCH"
+          python3 scripts/promote-product-docs.py \
+            --write \
+            --source-sha "$SOURCE_SHA" \
+            --release-version "$RELEASE_VERSION"
+          python3 scripts/promote-product-docs.py --check
+          python3 scripts/check-doc-links.py
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md .github/release-provenance.json
+          git diff --cached --quiet && {
+            echo "No product documentation projection changes were generated." >&2
+            exit 1
+          }
+          git commit -m "docs: project product documentation for $RELEASE_VERSION"
+          git push origin "HEAD:$RELEASE_BRANCH"
+
+      - name: Open reviewed main promotion pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          body_file="$RUNNER_TEMP/product-promotion.md"
+          cat > "$body_file" <<EOF
+          ## Controlled product promotion
+
+          This pull request was generated from the exact dev commit $SOURCE_SHA.
+
+          It contains the complete dev product snapshot plus the generated stable root
+          README and release provenance. Review the full code and product documentation
+          together. Do not merge if dev has moved or if the generated README projection
+          is stale.
+
+          The stable CI verifies the recorded dev SHA, the projection, documentation
+          links, package checks, and marketplace preflight before merge.
+          EOF
+          gh pr create \
+            --base main \
+            --head "$RELEASE_BRANCH" \
+            --title "Promote $RELEASE_VERSION product snapshot to main" \
+            --body-file "$body_file"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,5 +49,13 @@ jobs:
       - name: Validate relative links
         run: python3 scripts/check-doc-links.py
 
+      - name: Validate canonical product documentation source
+        if: github.base_ref == 'dev' || github.ref == 'refs/heads/dev'
+        run: python3 scripts/promote-product-docs.py --check-source
+
+      - name: Validate stable README projection
+        if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
+        run: python3 scripts/promote-product-docs.py --check
+
       - name: Build documentation
         run: mdbook build

--- a/.github/workflows/verify-bundled-backend.yml
+++ b/.github/workflows/verify-bundled-backend.yml
@@ -71,15 +71,28 @@ jobs:
       - name: Verify the bundled package
         run: PATH="$RUNNER_TEMP/omagen-ci-bin:$PATH" OMAGEN_HEADLESS_CI=1 GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh
 
-      - name: Enforce stable promotion source
+      - name: Enforce stable promotion provenance
         if: github.event_name == 'pull_request' && github.base_ref == 'main'
         env:
           SOURCE_BRANCH: ${{ github.head_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          test "$SOURCE_BRANCH" = dev || {
-            echo "Stable main promotions must originate from dev (got $SOURCE_BRANCH)." >&2
-            exit 1
-          }
+          case "$SOURCE_BRANCH" in
+            release/*) ;;
+            *)
+              echo "Stable main promotions must use a generated release/* branch (got $SOURCE_BRANCH)." >&2
+              exit 1
+              ;;
+          esac
+          git fetch origin refs/heads/dev:refs/remotes/origin/dev
+          dev_sha="$(git rev-parse refs/remotes/origin/dev)"
+          python3 scripts/verify-main-promotion.py \
+            --expected-dev-sha "$dev_sha" \
+            --head-sha "$HEAD_SHA"
+
+      - name: Verify stable product README projection
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        run: python3 scripts/promote-product-docs.py --check
 
       - name: Record build provenance
         run: |

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Omagen](README.md)
 - [Documentation index](docs/README.md)
+  - [Product documentation source](docs/product/README.md)
   - [Examples](docs/examples.md)
   - [Usage](docs/usage.md)
   - [Styling and palette settings](docs/styling.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,13 @@ the user workflow, then use the focused guides for styling, Demo, recovery, or
 development. Contributors should start with [the root agent guide](../AGENTS.md)
 and the bounded-context routes in [docs/agents](agents/README.md).
 
+Product-facing README, screenshots, demos, examples, and release material are
+authored in the [canonical product documentation source](product/README.md).
+Use the [product README authoring guide](product/README.authoring.md) while
+writing it.
+The root README remains developer-facing on `nightly` and `dev`; the controlled
+release workflow projects the product README to the root of `main`.
+
 - [Examples](examples.md) — wallpaper and generated-theme pairs.
 - [Usage](usage.md) — choose an image, generate six palette directions, use
   Live Canvas Preview and Test Live, run Demo, and apply a theme.

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,8 +47,10 @@ bin/omagen                Bundled runtime backend binary
 demo/                     Deterministic Demo workspace assets
 assets/                   README and documentation media
 docs/                     User and contributor guides
+docs/product/             Canonical product README, assets, demos, and release docs
 docs/development/         Focused developer runbooks and health notes
 scripts/v1-check.sh       Full validation gate
+scripts/promote-product-docs.py  Stable README projection and link validation
 dev-install.sh            Local development installer
 uninstall.sh              Complete local/plugin-state uninstaller
 ~~~

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -16,6 +16,12 @@ nightly → dev → release candidate → main → marketplace verification
 - `main` is the stable product branch. It contains the user-facing product
   README, demos, installation, usage, recovery, and release notes.
 
+The root README is intentionally different by branch. `nightly` and `dev` keep
+their developer README. Product-facing material is authored canonically under
+[`docs/product/`](../product/README.md), then projected to the root during a
+controlled release promotion. This keeps developer navigation stable while
+making the stable branch present one coherent product.
+
 Never promote `nightly` directly to `main`. A promotion pull request is the
 audit boundary between each branch.
 
@@ -27,14 +33,36 @@ The `v2.0.0` release uses these immutable states:
 2. The validated `dev` head receives a candidate tag such as `v2.0.0-rc.1`.
 3. Candidate testing is repeated with a new tag whenever the source commit
    changes.
-4. The final reviewed `dev` head is promoted to `main`.
-5. The exact stable `main` commit receives the `v2.0.0` tag.
-6. Only that exact full SHA is submitted to or updated in the Omarchy plugin
+4. The release workflow creates a `release/*` branch from that exact `dev`
+   head, projects the canonical product README to the repository root, and
+   opens one reviewed pull request into `main`.
+5. The complete generated release branch, including all product code and
+   product documentation, is merged into `main`.
+6. The exact stable `main` commit receives the `v2.0.0` tag.
+7. Only that exact full SHA is submitted to or updated in the Omarchy plugin
    marketplace.
 
 Both `manifest.json` and `bar-manifest.json` are one source-wide plugin set.
 Their IDs, entry points, ownership, and synchronized versions must remain
 unchanged during candidate approval unless the release is restarted.
+
+## Product documentation promotion
+
+Product documentation is prepared in `docs/product/` on `nightly`, reviewed
+and validated on `dev`, and is not copied into the developer README. When the
+validated `dev` head is ready, run the **Product documentation promotion**
+workflow from the repository's Actions page with:
+
+- the exact full SHA of the current `dev` head;
+- the release version, such as `v2.0.0`; and
+- a new `release/<version>` branch name.
+
+The workflow refuses a moved or mutable `dev` source, validates product links,
+projects the canonical README to the repository root, records
+`.github/release-provenance.json`, and opens a pull request into `main`. It does
+not write directly to or merge the protected stable branch. The resulting
+release pull request is the single review boundary for the complete product
+code and the stable product presentation.
 
 ## Required gates
 
@@ -97,9 +125,12 @@ Users must still inspect the source and decide whether to trust the plugin.
 - [ ] Fresh-package validation passes from a clean Git-backed package fixture.
 - [ ] Marketplace preflight is `passed` or has exact maintainer-approved
   `review-required` evidence.
-- [ ] The developer README has been replaced by the stable product README on
-  `main`, with demos, screenshots, installation, upgrade, recovery, and
-  release notes visible at the repository root.
+- [ ] The canonical `docs/product/` source is complete and reviewed.
+- [ ] The generated release branch records the exact `dev` SHA in
+  `.github/release-provenance.json`.
+- [ ] The developer README remains on `nightly` and `dev`; the projected stable
+  product README is present at the root of `main`, with demos, screenshots,
+  installation, upgrade, recovery, and release notes visible.
 - [ ] Release notes describe capabilities, trust boundaries, limitations, and
   recovery.
 
@@ -109,7 +140,8 @@ Configure GitHub repository rules so that:
 
 - `dev` and `main` require pull requests and passing required checks.
 - `dev` and `main` reject force-pushes and branch deletion.
-- `main` promotion pull requests must originate from `dev`.
+- `main` promotion pull requests must use a generated `release/*` branch whose
+  provenance points to the current exact `dev` head.
 - Stable release tags can only be created from protected `main` heads.
 - Required checks are dismissed when new commits are pushed.
 - At least one maintainer approval is required for promotion.

--- a/docs/product/README.authoring.md
+++ b/docs/product/README.authoring.md
@@ -1,0 +1,23 @@
+# Product README authoring guide
+
+`README.md` in this directory is the canonical source for the stable product
+README. Write it for users, not contributors. The root README on `nightly` and
+`dev` remains the developer guide until the controlled release promotion.
+
+Keep the product README focused on the user journey:
+
+- the problem Omagen solves and the visual result;
+- screenshots, demos, and curated examples;
+- stable installation, first use, and normal usage;
+- upgrade, recovery, rollback, and removal;
+- capabilities, trust boundaries, ownership, and limitations; and
+- links to the complete product documentation under this directory.
+
+Use `<!-- omagen-product-source-only:start -->` and
+`<!-- omagen-product-source-only:end -->` around maintainer instructions that
+are useful while authoring but must not appear in the stable root README.
+
+The promotion workflow validates links from this directory, rewrites relative
+links for the root README projection, records the exact `dev` source SHA, and
+opens a reviewed pull request into `main`. Do not manually edit the projected
+root README on `dev` or `nightly`.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,61 @@
+<!-- omagen-product-readme: canonical-source -->
+# Omagen
+
+<!-- omagen-product-source-only:start -->
+> This is the canonical product README source. On `nightly` and `dev`, the
+> repository root README intentionally remains developer-facing. The release
+> workflow projects this document to the repository root for `main`.
+<!-- omagen-product-source-only:end -->
+
+Omagen is an Omarchy Quattro plugin for generating and safely applying themes
+from images. It includes two separately owned packages:
+
+- `pretty.omagen` — the image generator overlay and launcher/status widget.
+- `pretty.omagen.bar` — the optional full-bar plugin.
+
+## Product overview
+
+<!-- TODO: Write the user-facing overview, value proposition, and release
+     highlights here. Keep implementation details in docs/development/. -->
+
+## Demos and examples
+
+<!-- TODO: Add the product screenshots, demo recording, and curated examples.
+     Keep their source assets under docs/product/assets/. -->
+
+- [Product assets and asset checklist](assets/README.md)
+- [Demo materials](demos/README.md)
+- [Examples](examples/README.md)
+
+## Installation
+
+<!-- TODO: Document the stable Omarchy plugin-manager installation command and
+     the exact stable release/version being installed. Do not add a mutable
+     nightly or dev install path here. -->
+
+## Usage
+
+<!-- TODO: Document the first-run workflow, image selection, generation,
+     Preview, Demo, Apply, Cancel, and Quit in product language. -->
+
+## Upgrade, recovery, and removal
+
+<!-- TODO: Document the supported upgrade from the current stable release,
+     ownership-aware recovery, rollback, and removal of both packages. -->
+
+## Trust boundary and capabilities
+
+Omagen is unsandboxed user-level plugin code. The final product documentation
+must explain which user files, themes, settings, shell resources, and session
+paths it can modify, why bundled executables and an installer exist, and how
+recovery and uninstall preserve resources that Omagen does not own. Omagen does
+not require `sudo`, install system packages, or configure privileged services.
+
+The marketplace preflight is a release gate and exact-commit evidence; it is
+not a security certification, endorsement, or guarantee. See the developer
+[security policy](../../SECURITY.md) and [release process](../development/release-process.md)
+for the maintainer-level details.
+
+## License
+
+Omagen is released under the [MIT License](../../LICENSE).

--- a/docs/product/assets/README.md
+++ b/docs/product/assets/README.md
@@ -1,0 +1,9 @@
+# Product assets
+
+Store product-facing screenshots, demo recordings, and release artwork here.
+Use stable, descriptive filenames and keep source captures or editing files
+outside the plugin package when they are not needed by the documentation.
+
+Before promotion, every referenced asset must be present in the exact commit,
+have a reviewable license/provenance, and stay within the marketplace preview
+limits when used as a listing preview.

--- a/docs/product/demos/README.md
+++ b/docs/product/demos/README.md
@@ -1,0 +1,8 @@
+# Product demos
+
+This directory is the source for the stable product demo material. Add the
+final demo recording, a short explanation of the user journey it demonstrates,
+and any reproducible capture notes here.
+
+Do not put developer-only test harnesses or live-desktop setup instructions in
+this directory. Those belong in `docs/development/`.

--- a/docs/product/examples/README.md
+++ b/docs/product/examples/README.md
@@ -1,0 +1,8 @@
+# Product examples
+
+Curate user-facing examples here. Each example should explain what the user
+will see, identify the included asset files, and state whether it is a static
+example or a reproducible workflow.
+
+Implementation fixtures and compatibility snapshots remain in the existing
+developer documentation and test directories.

--- a/docs/product/release-notes/README.md
+++ b/docs/product/release-notes/README.md
@@ -1,0 +1,6 @@
+# Product release notes
+
+Release notes prepared for `main` belong here. They should be written for
+users, explain upgrade and recovery implications, and link to the exact
+release/tag after it exists. Maintainer-only validation evidence remains in
+`docs/development/`.

--- a/scripts/promote-product-docs.py
+++ b/scripts/promote-product-docs.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Validate and project the canonical product README onto the stable root.
+
+The source document lives at ``docs/product/README.md`` so nightly and dev can
+keep a developer-facing repository README. A release branch generated from an
+exact dev commit runs ``--write`` to materialize the source at ``README.md``.
+The transformation is deterministic for the README itself: relative links are
+resolved from the source location and rewritten for the repository root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from posixpath import relpath
+
+
+POLICY_VERSION = "product-docs-projection-v1"
+SOURCE_README = Path("docs/product/README.md")
+ROOT_README = Path("README.md")
+MARKER = "<!-- omagen-product-readme: canonical-source -->"
+SOURCE_ONLY = re.compile(
+    r"<!-- omagen-product-source-only:start -->.*?<!-- omagen-product-source-only:end -->[ \t]*(?:\n[ \t]*)*",
+    re.DOTALL,
+)
+MARKDOWN_LINK = re.compile(r"\]\(([^)\n]+)\)")
+EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "#")
+
+
+def split_target(raw_target: str) -> tuple[str, str, str]:
+    """Return path, suffix, and optional markdown title from a link target."""
+
+    target = raw_target.strip()
+    if target.startswith("<") and ">" in target:
+        close = target.index(">")
+        path = target[1:close]
+        remainder = target[close + 1 :]
+        return path, "", remainder
+
+    match = re.match(r"([^\s]+)(\s+.*)?$", target)
+    if not match:
+        return target, "", ""
+    path_with_suffix = match.group(1)
+    title = match.group(2) or ""
+    suffix_match = re.match(r"([^#?]*)(.*)$", path_with_suffix)
+    assert suffix_match is not None
+    return suffix_match.group(1), suffix_match.group(2), title
+
+
+def is_external(path: str) -> bool:
+    return not path or path.startswith(EXTERNAL_PREFIXES) or path.startswith("/")
+
+
+def resolve_local(root: Path, source: Path, link_path: str) -> Path:
+    resolved = (source.parent / link_path).resolve()
+    root_resolved = root.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ValueError(
+            f"{source.relative_to(root)}: relative link escapes repository: {link_path}"
+        ) from exc
+    return resolved
+
+
+def validate_markdown_links(root: Path, directory: Path) -> list[str]:
+    errors: list[str] = []
+    if not directory.is_dir():
+        return [f"missing product documentation directory: {directory.relative_to(root)}"]
+
+    for source in sorted(directory.rglob("*.md")):
+        text = source.read_text(encoding="utf-8")
+        for raw_target in MARKDOWN_LINK.findall(text):
+            link_path, _, _ = split_target(raw_target)
+            if is_external(link_path):
+                continue
+            try:
+                resolved = resolve_local(root, source, link_path)
+            except ValueError as exc:
+                errors.append(str(exc))
+                continue
+            if not resolved.exists():
+                errors.append(
+                    f"{source.relative_to(root)}: missing relative link: {link_path}"
+                )
+    return errors
+
+
+def rewrite_link(root: Path, source: Path, raw_target: str) -> str:
+    link_path, suffix, title = split_target(raw_target)
+    if is_external(link_path):
+        return raw_target
+
+    resolved = resolve_local(root, source, link_path)
+    destination = Path(relpath(resolved, root.resolve())).as_posix()
+    rewritten = f"{destination}{suffix}{title}"
+    if raw_target.strip().startswith("<"):
+        return f"<{destination}{suffix}>{title}"
+    return rewritten
+
+
+def render_readme(root: Path) -> str:
+    source = root / SOURCE_README
+    if not source.is_file():
+        raise ValueError(f"missing canonical product README: {SOURCE_README}")
+    source_text = source.read_text(encoding="utf-8")
+    if MARKER not in source_text:
+        raise ValueError(f"canonical README is missing marker: {MARKER}")
+    source_text = SOURCE_ONLY.sub("", source_text)
+
+    def replace(match: re.Match[str]) -> str:
+        return "](" + rewrite_link(root, source, match.group(1)) + ")"
+
+    return MARKDOWN_LINK.sub(replace, source_text)
+
+
+def validate_source(root: Path) -> None:
+    source = root / SOURCE_README
+    if not source.is_file():
+        raise ValueError(f"missing canonical product README: {SOURCE_README}")
+    required = (
+        root / "docs/product/assets/README.md",
+        root / "docs/product/demos/README.md",
+        root / "docs/product/examples/README.md",
+        root / "docs/product/release-notes/README.md",
+    )
+    missing = [path.relative_to(root) for path in required if not path.is_file()]
+    if missing:
+        raise ValueError("missing product documentation files: " + ", ".join(map(str, missing)))
+    errors = validate_markdown_links(root, root / "docs/product")
+    if errors:
+        raise ValueError("\n".join(errors))
+
+
+def write_provenance(root: Path, source_sha: str, release_version: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        raise ValueError("--source-sha must be a full lowercase 40-character commit SHA")
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", release_version):
+        raise ValueError("--release-version must be a semantic version beginning with v")
+
+    provenance = {
+        "schemaVersion": 1,
+        "policyVersion": POLICY_VERSION,
+        "sourceBranch": "dev",
+        "sourceSha": source_sha,
+        "releaseVersion": release_version,
+        "generatedFiles": [str(ROOT_README)],
+        "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    path = root / ".github/release-provenance.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(provenance, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check-source", action="store_true")
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--write", action="store_true")
+    parser.add_argument("--source-sha")
+    parser.add_argument("--release-version")
+    args = parser.parse_args()
+    root = args.root.resolve()
+
+    try:
+        validate_source(root)
+        rendered = render_readme(root)
+        if args.check_source:
+            print("Product documentation source: PASS")
+        elif args.check:
+            actual = (root / ROOT_README).read_text(encoding="utf-8")
+            if actual != rendered:
+                print("README.md is not the projection of docs/product/README.md", file=sys.stderr)
+                return 1
+            print("Product documentation projection: PASS")
+        else:
+            if bool(args.source_sha) != bool(args.release_version):
+                raise ValueError("--source-sha and --release-version must be provided together")
+            (root / ROOT_README).write_text(rendered, encoding="utf-8")
+            if args.source_sha:
+                write_provenance(root, args.source_sha, args.release_version)
+            print(f"Projected {SOURCE_README} to {ROOT_README}")
+    except (OSError, ValueError) as exc:
+        print(f"Product documentation projection failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-product-docs-promotion.py
+++ b/scripts/test-product-docs-promotion.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Tests for the branch-specific product README projection."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/promote-product-docs.py"
+VERIFY_SCRIPT = ROOT / "scripts/verify-main-promotion.py"
+
+
+def run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(SCRIPT), "--root", str(cwd), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def run_verify(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(VERIFY_SCRIPT), "--root", str(cwd), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="omagen-product-docs-") as temporary:
+        root = Path(temporary)
+        product = root / "docs/product"
+        for directory in (product / "assets", product / "demos", product / "examples", product / "release-notes"):
+            directory.mkdir(parents=True)
+            (directory / "README.md").write_text("# Placeholder\n", encoding="utf-8")
+        (root / "CONTRIBUTING.md").write_text("# Contributing\n", encoding="utf-8")
+        (product / "README.md").write_text(
+            "<!-- omagen-product-readme: canonical-source -->\n"
+            "# Product\n\n"
+            "<!-- omagen-product-source-only:start -->\n"
+            "> authoring note\n"
+            "<!-- omagen-product-source-only:end -->\n\n"
+            "[Install](installation.md) [Asset](assets/README.md) "
+            "[Contribute](../../CONTRIBUTING.md) [External](https://example.com)\n",
+            encoding="utf-8",
+        )
+        (product / "installation.md").write_text("# Install\n", encoding="utf-8")
+        (root / "README.md").write_text("# Developer README\n", encoding="utf-8")
+
+        checked = run("--check-source", cwd=root)
+        if checked.returncode != 0:
+            print(checked.stderr, end="")
+            return 1
+        written = run("--write", cwd=root)
+        if written.returncode != 0:
+            print(written.stderr, end="")
+            return 1
+        expected = (
+            "<!-- omagen-product-readme: canonical-source -->\n"
+            "# Product\n\n"
+            "[Install](docs/product/installation.md) [Asset](docs/product/assets/README.md) "
+            "[Contribute](CONTRIBUTING.md) [External](https://example.com)\n"
+        )
+        if (root / "README.md").read_text(encoding="utf-8") != expected:
+            print("unexpected projected README", file=sys.stderr)
+            return 1
+        verified = run("--check", cwd=root)
+        if verified.returncode != 0:
+            print(verified.stderr, end="")
+            return 1
+
+        (root / ".github").mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "Product Docs Test"], cwd=root, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "test"], cwd=root, check=True)
+        source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+        provenance_written = run(
+            "--write",
+            "--source-sha",
+            source_sha,
+            "--release-version",
+            "v2.0.0",
+            cwd=root,
+        )
+        if provenance_written.returncode != 0:
+            print(provenance_written.stderr, end="")
+            return 1
+        provenance = run_verify(
+            "--expected-dev-sha",
+            source_sha,
+            "--head-sha",
+            source_sha,
+            cwd=root,
+        )
+        if provenance.returncode != 0:
+            print(provenance.stderr, end="")
+            return 1
+    print("Product documentation projection tests: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/v1-check.sh
+++ b/scripts/v1-check.sh
@@ -30,6 +30,15 @@ section "Repository"
 section "Architecture routing"
 "$ROOT/scripts/architecture-check.sh"
 
+section "Product documentation projection"
+python3 "$ROOT/scripts/test-product-docs-promotion.py"
+branch="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
+if [[ "$branch" == "main" || "${GITHUB_BASE_REF:-}" == "main" || "${GITHUB_REF:-}" == "refs/heads/main" ]]; then
+    python3 "$ROOT/scripts/promote-product-docs.py" --check
+else
+    python3 "$ROOT/scripts/promote-product-docs.py" --check-source
+fi
+
 section "Go tests"
 (cd "$BACKEND" && go test ./...)
 
@@ -148,9 +157,18 @@ required=(
     "bin/omagen-studio"
     "scripts/marketplace-preflight.py"
     "scripts/test-marketplace-preflight.py"
+    "scripts/promote-product-docs.py"
+    "scripts/test-product-docs-promotion.py"
+    "scripts/verify-main-promotion.py"
     "scripts/verify-shader-provenance.py"
     "scripts/test-fresh-package.sh"
     "docs/shader-provenance.json"
+    "docs/product/README.md"
+    "docs/product/README.authoring.md"
+    "docs/product/assets/README.md"
+    "docs/product/demos/README.md"
+    "docs/product/examples/README.md"
+    "docs/product/release-notes/README.md"
     "NOTICE.md"
     "qml/services/BackendService.qml"
     "qml/gateways/BackendCommand.qml"

--- a/scripts/verify-main-promotion.py
+++ b/scripts/verify-main-promotion.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verify that a main promotion branch was generated from the current dev head."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--expected-dev-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    args = parser.parse_args()
+    path = args.root / ".github/release-provenance.json"
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Missing or malformed release provenance: {exc}", file=sys.stderr)
+        return 1
+
+    source_sha = data.get("sourceSha")
+    if data.get("schemaVersion") != 1 or data.get("policyVersion") != "product-docs-projection-v1":
+        print("Unsupported release provenance policy", file=sys.stderr)
+        return 1
+    if data.get("sourceBranch") != "dev":
+        print("Release provenance sourceBranch must be dev", file=sys.stderr)
+        return 1
+    if not isinstance(source_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        print("Release provenance sourceSha must be a full lowercase SHA", file=sys.stderr)
+        return 1
+    if source_sha != args.expected_dev_sha:
+        print("Release branch was not generated from the current dev head", file=sys.stderr)
+        return 1
+    if not re.fullmatch(r"[0-9a-f]{40}", args.head_sha):
+        print("--head-sha must be a full lowercase SHA", file=sys.stderr)
+        return 1
+
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", source_sha, args.head_sha],
+        cwd=args.root,
+        check=False,
+    )
+    if result.returncode != 0:
+        print("Release head does not contain the recorded dev source commit", file=sys.stderr)
+        return 1
+    print(f"Main promotion provenance: PASS (dev {source_sha})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the canonical product-documentation source and the controlled projection used for stable `main` releases.

- `nightly` and `dev` retain developer-facing root README files.
- Product content is authored under `docs/product/`.
- A controlled Actions workflow creates a `release/*` branch from an exact `dev` SHA, projects the product README to the root, records provenance, and opens a reviewed PR into `main`.
- Stable CI validates the projection and exact `dev` provenance.

## Validation

- Full `GOCACHE=/tmp/omagen-gocache OMAGEN_HEADLESS_CI=1 ./scripts/v1-check.sh` passed.
- Product projection, provenance, documentation-link, and workflow YAML checks passed.
- Live Omarchy testing was not run.
