### PR TITLE
fix stable marketplace baseline for v2 promotion

### DIFF
--- a/.github/workflows/verify-bundled-backend.yml
+++ b/.github/workflows/verify-bundled-backend.yml
@@ -136,12 +136,30 @@ jobs:
           fetch-depth: 0
 
       - name: Run deterministic static preflight
+        env:
+          PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           mkdir -p artifacts
           python3 scripts/test-marketplace-preflight.py
+          compare_to="$PR_BASE_SHA"
+          if [ "$PR_BASE_BRANCH" = "main" ]; then
+            # A v2 release intentionally adds pretty.omagen.bar compared with
+            # the old v1 main branch. Compare stable candidates with the exact
+            # dev source recorded by the generated release provenance instead.
+            compare_to="$(python3 -c 'import json, pathlib, re; value=json.loads(pathlib.Path(".github/release-provenance.json").read_text(encoding="utf-8")).get("sourceSha"); print(value if isinstance(value, str) and re.fullmatch(r"[0-9a-f]{40}", value) else "")')"
+            test -n "$compare_to" || {
+              echo "stable marketplace preflight requires a valid release provenance sourceSha" >&2
+              exit 1
+            }
+          fi
+          compare_args=()
+          if [ -n "$compare_to" ]; then
+            compare_args+=(--compare-to "$compare_to")
+          fi
           python3 scripts/marketplace-preflight.py \
             --commit "$(git rev-parse HEAD)" \
-            ${{ github.event.pull_request.base.sha && format('--compare-to {0}', github.event.pull_request.base.sha) || '' }} \
+            "${compare_args[@]}" \
             --report artifacts/marketplace-preflight.json
 
       - name: Upload commit-bound security evidence

--- a/docs/development/nightly-to-dev-handoff.md
+++ b/docs/development/nightly-to-dev-handoff.md
@@ -11,7 +11,7 @@ working tree or reuse evidence from another commit.
 - Release target: `v2.0.0`
 - Packages: `pretty.omagen`, `pretty.omagen.bar`
 - Candidate tag: create only after the promotion PR passes the `dev` gate.
-- Promotion commit: `TBD — fill after review and commit`
+- Promotion commit: `f4cb7ea25562386a149358228d1ce64cd5f26b1a`
 
 The product changes include Demo reader and workspace lifecycle behavior,
 Preview stale-work protection, QML controller sequencing, full-bar integration,
@@ -54,7 +54,8 @@ results rather than relying only on commit ancestry.
 - [x] Shader source/QSB provenance.
 - [x] Fresh-package validation.
 - [x] Documentation relative-link validation.
-- [ ] CI run on the actual `nightly → dev` pull request.
+- [x] CI run on the actual `nightly → dev` pull request (`#4`; head
+  `475768f01d5b7ce9dfa4489c7979dd144f2c2f4f`; merged as the commit above).
 
 The local preflight outcome is `review-required` with no findings because the
 package intentionally contains a bundled executable and installer/runtime

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -90,6 +90,13 @@ The preflight is not a security audit, certification, endorsement, or safety
 guarantee. Omagen remains unsandboxed plugin code; release documentation must
 describe what it can modify and how users can recover or uninstall it.
 
+On a pull request targeting `dev`, the manifest comparison baseline is the
+pull request's previous `dev` head. On a generated release pull request
+targeting `main`, the baseline is the exact `sourceSha` recorded in
+`.github/release-provenance.json`, not the older stable branch. This preserves
+the intentional v2 addition of `pretty.omagen.bar` while still proving that
+the stable projection did not alter the reviewed source-wide manifest set.
+
 ## Marketplace submission
 
 After the stable `main` commit is immutable:


### PR DESCRIPTION
## Summary

Promote the final release-process fixes into protected `dev`.

- Stable marketplace preflight now compares the generated release branch with the exact `dev` source recorded in `.github/release-provenance.json`.
- This preserves the intentional v2 addition of `pretty.omagen.bar` while still detecting changes to the reviewed manifest set.
- Completes the exact `nightly → dev` promotion handoff record for PR #4.

## Validation

- Local `scripts/v1-check.sh` — PASS
- Marketplace preflight tests — PASS
- Workflow YAML parse — PASS
- No live desktop testing was run.

## Next step

After this PR is merged and its post-merge `dev` checks pass, create `v2.0.0-rc.1` from the exact `dev` head and run the Product Documentation Promotion workflow to generate the reviewed `release/v2.0.0` branch.