### PR TITLE
harden stable release validation

### DIFF
--- a/scripts/test-fresh-package.sh
+++ b/scripts/test-fresh-package.sh
@@ -4,7 +4,11 @@ set -Eeuo pipefail
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/omagen-fresh-package.XXXXXXXX")"
 cleanup() {
-    rm -rf -- "$TEMP_ROOT"
+    if ! rm -rf -- "$TEMP_ROOT"; then
+        # The fixture has already passed its checks. Do not turn a runner
+        # cleanup race into a false validation failure or hide the real result.
+        printf 'fresh package: cleanup warning: could not remove %s\n' "$TEMP_ROOT" >&2
+    fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary

Promote the final release-validation fixes into protected `dev`.

- Stable marketplace preflight compares against the exact generated-release source SHA, allowing the intentional v2 `pretty.omagen.bar` addition while detecting stable-source drift.
- Fresh-package cleanup warnings can no longer turn an already-passing validation into a false failure.
- The nightly-to-dev handoff records the exact prior promotion and CI evidence.

## Validation

- Local `GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh` — PASS
- Marketplace preflight tests — PASS
- Workflow YAML parse — PASS
- Fresh-package validation repeated successfully
- No live desktop testing was run.

## Next step

After this promotion is merged and the post-merge `dev` checks pass, tag the exact `dev` head as `v2.0.0-rc.1` and run the Product Documentation Promotion workflow for `release/v2.0.0`.