### PR TITLE
ci: fetch history for stable promotion provenance

### DIFF
--- a/.github/workflows/verify-bundled-backend.yml
+++ b/.github/workflows/verify-bundled-backend.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up the pinned Go toolchain
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

Fetch the complete Git history in the bundled-backend workflow so the stable
promotion check can resolve the exact release-branch head SHA and verify that
the recorded `dev` source commit is its ancestor.

This is required for the controlled `nightly → dev → main` promotion flow.
