### PR TITLE
docs: rewrite HTML asset paths in product projection

### DIFF
--- a/scripts/promote-product-docs.py
+++ b/scripts/promote-product-docs.py
@@ -28,6 +28,7 @@ SOURCE_ONLY = re.compile(
     re.DOTALL,
 )
 MARKDOWN_LINK = re.compile(r"\]\(([^)\n]+)\)")
+HTML_SOURCE = re.compile(r"(?P<prefix>\bsrc=[\"'])(?P<target>[^\"']+)(?P<suffix>[\"'])")
 EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "#")
 
 
@@ -115,7 +116,17 @@ def render_readme(root: Path) -> str:
     def replace(match: re.Match[str]) -> str:
         return "](" + rewrite_link(root, source, match.group(1)) + ")"
 
-    return MARKDOWN_LINK.sub(replace, source_text)
+    projected = MARKDOWN_LINK.sub(replace, source_text)
+
+    def replace_html_source(match: re.Match[str]) -> str:
+        target = match.group("target")
+        return (
+            match.group("prefix")
+            + rewrite_link(root, source, target)
+            + match.group("suffix")
+        )
+
+    return HTML_SOURCE.sub(replace_html_source, projected)
 
 
 def validate_source(root: Path) -> None:

--- a/scripts/test-product-docs-promotion.py
+++ b/scripts/test-product-docs-promotion.py
@@ -47,10 +47,13 @@ def main() -> int:
             "> authoring note\n"
             "<!-- omagen-product-source-only:end -->\n\n"
             "[Install](installation.md) [Asset](assets/README.md) "
-            "[Contribute](../../CONTRIBUTING.md) [External](https://example.com)\n",
+            "[Contribute](../../CONTRIBUTING.md) [External](https://example.com)\n"
+            "<img src=\"../../assets/examples/example.webp\" alt=\"Example\">\n",
             encoding="utf-8",
         )
         (product / "installation.md").write_text("# Install\n", encoding="utf-8")
+        (root / "assets/examples").mkdir(parents=True)
+        (root / "assets/examples/example.webp").write_bytes(b"example")
         (root / "README.md").write_text("# Developer README\n", encoding="utf-8")
 
         checked = run("--check-source", cwd=root)
@@ -66,6 +69,7 @@ def main() -> int:
             "# Product\n\n"
             "[Install](docs/product/installation.md) [Asset](docs/product/assets/README.md) "
             "[Contribute](CONTRIBUTING.md) [External](https://example.com)\n"
+            "<img src=\"assets/examples/example.webp\" alt=\"Example\">\n"
         )
         if (root / "README.md").read_text(encoding="utf-8") != expected:
             print("unexpected projected README", file=sys.stderr)


### PR DESCRIPTION
## Summary

Rewrite local HTML `img src` paths alongside Markdown links when projecting the
canonical product README from `docs/product/README.md` to the stable root.
Add a regression test so product examples and bar screenshots render correctly
in both locations.
