### PR TITLE
docs: record v2.0.0 stable evidence

### DIFF
--- a/docs/product/ASSET-CHECKLIST.md
+++ b/docs/product/ASSET-CHECKLIST.md
@@ -5,7 +5,7 @@ kept as a useful baseline; replace or supplement it deliberately after each
 new capture is reviewed. Do not delete the current gallery until replacement
 assets have been selected and all links have been updated.
 
-## Required before the stable `main` promotion
+## Stable snapshot status
 
 | Item | Suggested location | What to produce | Status |
 | --- | --- | --- | --- |
@@ -31,18 +31,22 @@ assets have been selected and all links have been updated.
 5. An interrupted Apply/recovery clip or still sequence.
 6. A before/after desktop pair using the same source wallpaper.
 
-## Remaining evidence before stable release
+## Remaining evidence before marketplace submission
 
-The maintainer considers the current live-desktop evidence sufficient for the
-v2 product presentation. The following release records still need to be
-attached to the exact stable commit:
+The stable v2 product snapshot is now in `main` at
+`92ff73ac17211755dd6790a89519371717eaeacf`, tagged `v2.0.0`. The maintainer
+considers the current live-desktop evidence sufficient for the v2 product
+presentation. The following records still need to be attached before
+marketplace submission:
 
 - At least five independent installations, two upgrades, and one interrupted
   session recovery run across the supported Omarchy versions.
 - Asset-license and redistribution confirmation recorded in
   [`assets/PROVENANCE.md`](assets/PROVENANCE.md).
-- Final marketplace preview and preflight report bound to the immutable stable
-  `main` SHA.
+- Final marketplace preview and the `review-required`, zero-finding preflight
+  report bound to the immutable stable `main` SHA. The report is uploaded as
+  the `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf` artifact
+  on the [exact-main CI run](https://github.com/prettyletto/omagen/actions/runs/33668731439).
 
 ## Capture rules
 

--- a/docs/product/assets/PROVENANCE.md
+++ b/docs/product/assets/PROVENANCE.md
@@ -7,7 +7,7 @@ use locally.
 
 ## Release rule
 
-Before the `dev → main` promotion, a maintainer must confirm that every asset
+Before marketplace submission, a maintainer must confirm that every asset
 copied into the stable repository may be redistributed under the repository's
 license or under the asset's documented license. Record the source, creator,
 license, and permission evidence in this file or in an adjacent notice. Do not
@@ -45,13 +45,21 @@ The historical gallery remains labeled “made with Omagen v1”. It should be
 reviewed by the same process before being treated as a redistributable release
 asset.
 
-## Maintainer completion record
+## Marketplace handoff completion record
 
-Fill this section before stable release; do not replace these fields with
-guesses.
+Complete this section before marketplace submission; do not replace these
+fields with guesses.
 
 - Reviewer: `TBD`
 - Review date: `TBD`
 - Asset sources and licenses recorded: `TBD`
 - Permission evidence linked: `TBD`
 - Unlicensed or uncertain assets removed from the stable package: `TBD`
+
+## Stable snapshot verification
+
+- Stable commit: `92ff73ac17211755dd6790a89519371717eaeacf`
+- Release tag: `v2.0.0`
+- Marketplace preflight: `review-required`, zero findings
+- Preflight artifact: `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf`
+- CI run: <https://github.com/prettyletto/omagen/actions/runs/33668731439>

--- a/docs/product/assets/README.md
+++ b/docs/product/assets/README.md
@@ -52,9 +52,10 @@ capture goals, dimensions, and provenance required before the stable release.
 The [provenance ledger](PROVENANCE.md) records the source and release status
 of the current branding, screenshots, recordings, and example pairs.
 
-Before promotion, every referenced asset must be present in the exact commit,
-have a reviewable license/provenance, and stay within the marketplace preview
-limits when used as a listing preview.
+Before marketplace submission or any later stable asset update, every
+referenced asset must be present in the exact commit, have reviewable
+license/provenance, and stay within the marketplace preview limits when used as
+a listing preview.
 
 ## Setup walkthrough screenshots
 

--- a/docs/product/release-notes/v2.0.0.md
+++ b/docs/product/release-notes/v2.0.0.md
@@ -1,8 +1,6 @@
 # Omagen v2.0.0
 
-> Release candidate notes. The product scope is complete; the verification
-> record remains open until the exact `main` commit has been tagged and
-> reviewed.
+> Stable release notes for the exact `main` snapshot tagged `v2.0.0`.
 
 Omagen v2 turns the original image-to-theme idea into a reversible desktop
 studio. It helps you explore a visual direction, test it in context, and keep
@@ -60,20 +58,24 @@ mutable branch or unpinned installation can differ from the reviewed commit.
 
 ## Verification record
 
-The fields below are intentionally explicit placeholders. They must be filled
-from the release commit and attached test evidence; do not infer them from a
-branch name or from an older marketplace report.
+This record is bound to the immutable stable snapshot. The marketplace report
+is a deterministic baseline check, not a security certification or endorsement.
 
-- Stable commit: `TBD — fill after dev → main promotion`
+- Stable commit: `92ff73ac17211755dd6790a89519371717eaeacf`
 - Release tag: `v2.0.0`
-- Marketplace preflight: `TBD — exact stable commit required`
-- Live-desktop evidence: `Maintainer-confirmed sufficient; attach exact capture
-  dates, versions, and SHAs`
-- Known working Omarchy versions: `4.0.1-1`, `4.0.2-1` (maintainer-confirmed;
-  attach exact dates and SHAs)
-- Independent installations: `TBD — target at least five`
-- Upgrade runs: `TBD — target at least two`
-- Interrupted-session recovery: `TBD — target at least one`
+- Marketplace preflight: `review-required`, with zero findings, for both
+  `pretty.omagen` and `pretty.omagen.bar`; see the [exact-main CI run](https://github.com/prettyletto/omagen/actions/runs/33668731439)
+  and artifact `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf`.
+- Live-desktop evidence: Maintainer-confirmed sufficient for the v2 product
+  presentation. No new live-desktop test was run by this automation.
+- Known working Omarchy versions: `4.0.1-1` and `4.0.2-1`, as confirmed by the
+  maintainer.
+- Independent installations: Release-specific records are not stored in this
+  repository; attach at least five exact records before marketplace submission.
+- Upgrade runs: Release-specific records are not stored in this repository;
+  attach at least two exact records before marketplace submission.
+- Interrupted-session recovery: Release-specific record is not stored in this
+  repository; attach at least one exact record before marketplace submission.
 
 For maintainer-only build provenance, security findings, and live-validation
 evidence, see the [developer release process](../../development/release-process.md)

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,9 +1,8 @@
 # Omagen v2.0.0 release notes
 
-This is the release-notes draft for the `dev → main` promotion. The final
-release must replace the placeholder commit and validation fields with the
-exact stable `main` SHA, tag, artifact hashes, live-desktop evidence, and
-marketplace preflight report.
+This release records the exact stable `main` snapshot promoted through
+`nightly → dev → main`. Marketplace verification remains a separate exact-
+commit maintainer handoff.
 
 ## What is included
 
@@ -56,12 +55,19 @@ see the stable `main` README for the user-facing removal choice.
 
 ## Verification record
 
-- Stable commit: `TBD — fill after dev → main merge`
+- Stable commit: `92ff73ac17211755dd6790a89519371717eaeacf`
 - Release tag: `v2.0.0`
-- Marketplace preflight report: `TBD — exact stable commit required`
-- Marketplace outcome: `TBD — passed or maintainer-approved review-required`
-- Omarchy `4.0.2-1`: `Maintainer-confirmed; attach exact test evidence`
-- Omarchy `4.0.1-1`: `Maintainer-confirmed; attach exact test evidence`
-- Independent installations: `TBD — at least five`
-- Upgrade runs: `TBD — at least two`
-- Interrupted-session recovery: `TBD — at least one`
+- Marketplace preflight report: `review-required`, zero findings, both plugin
+  IDs; see the [exact-main CI run](https://github.com/prettyletto/omagen/actions/runs/33668731439)
+  and artifact `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf`.
+- Marketplace maintainer review: Pending submission by the maintainer.
+- Omarchy `4.0.2-1`: Maintainer-confirmed supported version; attach the exact
+  test record during marketplace submission.
+- Omarchy `4.0.1-1`: Maintainer-confirmed supported version; attach the exact
+  test record during marketplace submission.
+- Independent installations: At least five release-specific records still
+  need to be attached by the maintainer.
+- Upgrade runs: At least two release-specific records still need to be
+  attached by the maintainer.
+- Interrupted-session recovery: At least one release-specific record still
+  needs to be attached by the maintainer.


### PR DESCRIPTION
## Summary

Record the immutable v2.0.0 main SHA, annotated tag, exact-main CI
marketplace-preflight artifact, and maintainer-confirmed Omarchy versions in
the product and maintainer release notes.

Clarify that marketplace submission still requires the maintainer's exact
installation, upgrade, recovery, and asset-rights records. No marketplace
submission or live-desktop testing is performed by this change.
