### PR TITLE
docs: sync v2.0.0 evidence to main

### DIFF
--- a/.github/release-provenance.json
+++ b/.github/release-provenance.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "policyVersion": "product-docs-projection-v1",
+  "sourceBranch": "dev",
+  "sourceSha": "158d225e291e043707ae1619f4a81f9494becdf7",
+  "releaseVersion": "v2.0.0",
+  "generatedFiles": [
+    "README.md"
+  ],
+  "generatedAt": "2026-09-02T18:58:10.836576Z"
+}

--- a/README.md
+++ b/README.md
@@ -1,99 +1,193 @@
-# Omagen development branch
+<!-- omagen-product-readme: canonical-source -->
+![Omagen wordmark](docs/product/assets/branding/omagen-wordmark.png)
 
-This checkout is the `nightly` branch, intended for contributors and testers.
-It may contain incomplete or experimental work and must not be used as the
-normal user installation source. The controlled promotion path is:
+<div align="center">
 
-```text
-nightly → dev → main → marketplace verification
+# Omagen
+
+**Turn an image into an Omarchy desktop that feels like yours.**
+
+Generate a complete theme, explore meaningful variations, preview the result
+without committing to it, and apply it safely when it feels right.
+
+[![Build](https://img.shields.io/github/actions/workflow/status/prettyletto/omagen/verify-bundled-backend.yml?branch=main&style=flat-square&label=build)](https://github.com/prettyletto/omagen/actions)
+[![Documentation](https://img.shields.io/badge/docs-product%20guide-5b8def?style=flat-square)](docs/product/README.md)
+[![License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](LICENSE)
+
+[Get started](#get-started) · [See the workflow](#the-omagen-workflow) · [Browse examples](docs/product/examples/README.md) · [Read the product docs](#product-documentation)
+
+</div>
+
+![Omagen workflow preview](docs/product/assets/demos/omagen-demo-v2.gif)
+
+## Get started
+
+Omagen is built for Omarchy Quattro with Hyprland and Quickshell on Linux
+x86_64. Install the stable repository through Omarchy's plugin manager:
+
+```sh
+omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes
 ```
 
-The `dev` branch is the protected integration and release-candidate branch.
-The `main` branch owns the stable product README, demos, screenshots, user
-installation, upgrade, recovery, and release notes. See the [stable product
-README](https://github.com/prettyletto/omagen/blob/main/README.md) for the
-user-facing experience.
+Then open Omagen from the Omarchy launcher, choose a local image, review a
+palette direction, and use **Preview** or **Demo** before selecting **Apply**.
+The [getting started guide](docs/product/getting-started.md) covers requirements, first
+launch, optional applications, and removal.
 
-## Contributor setup
+To remove the packages later:
 
-Omagen is an Omarchy Quattro plugin composed of two separately owned packages:
-
-- `pretty.omagen` — the overlay and launcher/status widget.
-- `pretty.omagen.bar` — the optional full-bar plugin.
-
-Runtime requirements are Omarchy Quattro, Hyprland, Quickshell, and Linux
-x86_64 for the bundled backend executable. Demo applications are optional and
-are resolved with fallbacks. The plugin is unsandboxed and can modify the
-user-level themes, settings, shell state, backgrounds, and Omagen-owned
-session resources described in the [architecture](docs/architecture/README.md).
-It does not require `sudo`, install system packages, or configure privileged
-services.
-
-Clone the repository and install the current checkout locally:
-
-```zsh
-git clone https://github.com/prettyletto/omagen.git
-cd omagen
-./dev-install.sh
-```
-
-For tester or release-candidate validation, inspect an immutable full commit
-before installing it. The bootstrap refuses a mutable branch head:
-
-```zsh
-git clone https://github.com/prettyletto/omagen.git /tmp/omagen-review
-cd /tmp/omagen-review
-git show --stat --oneline <full-40-character-commit-sha>
-OMAGEN_TEST_BRANCH=nightly \
-OMAGEN_TEST_COMMIT=<full-40-character-commit-sha> \
-  ./scripts/install-branch.sh
-```
-
-Run the local repository gate from zsh:
-
-```zsh
-GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh
-python3 scripts/marketplace-preflight.py \
-  --commit "$(git rev-parse HEAD)" \
-  --report /tmp/omagen-marketplace-report.json
-```
-
-The preflight is deterministic, read-only, and never executes plugin code or
-downloaded content. It scans both manifests source-wide, checks the root
-packaging contract, records capabilities and findings against the exact commit,
-and returns `passed`, `review-required`, or `needs-fixes`.
-
-## Developer documentation
-
-- [Development guide](docs/development.md) — local setup, tests, packaging,
-  QML validation, and the repository gate.
-- [Release and promotion process](docs/development/release-process.md) —
-  branch contracts, candidate states, exact-commit evidence, and marketplace
-  submission.
-- [Architecture](docs/architecture/README.md) — plugin boundaries, the
-  QML/backend contract, generation, lifecycle, and recovery ownership.
-- [Demo workspace](docs/demo.md) — implementation and ownership contracts for
-  the temporary Demo paths.
-- [Contributing](CONTRIBUTING.md) — pull requests, reviews, and validation
-  expectations.
-- [Security policy](SECURITY.md) — trust boundaries and vulnerability reports.
-
-## Removal during development
-
-From a local checkout, run:
-
-```zsh
-./uninstall.sh
-```
-
-The uninstaller recovers an active Omagen session and preserves permanent
-themes, unrelated plugins, and resources without Omagen ownership markers.
-For package-only removal, use the native plugin manager explicitly:
-
-```zsh
+```sh
 omarchy plugin remove pretty.omagen --yes
 omarchy plugin remove pretty.omagen.bar --yes
 ```
 
-The stable `main` branch must retain the user-facing installation and removal
-instructions in its own root README before the final release promotion.
+Removing the plugins does not delete permanent themes created by you. If an
+Omagen session is active, use its recovery or restore path before removing
+state manually.
+
+## What is Omagen?
+
+Omagen is an image-to-theme studio for [Omarchy Quattro](https://omarchy.org/).
+It turns the colors and atmosphere of a source image into a coherent desktop
+direction, then gives you a safe way to judge that direction before it becomes
+permanent.
+
+The experience is designed around a simple loop:
+
+```text
+image → palette directions → preview or Demo → apply or cancel
+```
+
+Omagen is one product suite with two technical plugin packages:
+
+- `pretty.omagen` provides the Studio overlay, image generation, previews,
+  Demo, lifecycle, recovery, and the launcher/status widget.
+- `pretty.omagen.bar` is the optional full-bar experience for users who want
+  Omagen's Bar presets and behavior as their active bar.
+
+They remain separate because Omarchy registers overlays/widgets and full bars
+as different plugin kinds. They are presented as one suite, but the full bar
+is explicit and opt-in so installing Omagen does not silently replace the
+native Quattro bar.
+
+## Why Omagen?
+
+- Start from an image you already like instead of tuning colors from scratch.
+- Compare six generated directions: Source, Calm, Mute, Deep, Vibrant, and
+  Balanced.
+- Preview Window, Shell, Bar, and Animation choices in context when you want
+  more than a palette.
+- Open a temporary Demo workspace to judge the theme across real desktop
+  surfaces.
+- Apply a named theme only when you are satisfied—or Cancel and leave the
+  current desktop unchanged.
+- Recover an interrupted session through the durable session record instead of
+  guessing which temporary files are safe to remove.
+
+## The Omagen workflow
+
+### 1. Choose an image
+
+Choose a local image in a common raster format. Omagen extracts representative
+colors and keeps the selected image as the visual source for the session.
+
+### 2. Explore directions
+
+Review six palette directions generated by the same production pipeline used by
+the applied theme. The gallery is meant to help you choose a mood, not just a
+single dominant color.
+
+### 3. Preview safely
+
+Use Live Canvas to inspect the staged result. Use **Test live** for a reversible
+desktop preview, or open **Demo** to see the composition across a temporary
+editor, terminal, system monitor, and file manager workspace.
+
+### 4. Apply or cancel
+
+**Apply** writes a named permanent theme after the staged session is ready.
+**Cancel** restores the original theme, background, and Omagen-owned temporary
+resources. **Quit** uses the same recovery path when a session is active.
+
+### 5. Recover when interrupted
+
+If Omagen or the shell is interrupted during a preview or Apply, the next
+launch presents an explicit recovery choice. Restore the original desktop or
+resume the staged workspace when it can still be verified safely.
+
+## See it in action
+
+[![Watch the Omagen walkthrough](docs/product/assets/social/omagen-walkthrough-thumbnail-v2.png)](https://youtu.be/juDJe0zWwZI)
+
+Watch the [full Omagen walkthrough on YouTube](https://youtu.be/juDJe0zWwZI)
+for the image-to-theme flow, preview paths, Demo, and Apply experience.
+
+## Bar examples
+
+Here are a few examples of the optional Omagen bar direction across different
+placements and information densities. The full bar is an opt-in part of the
+Omagen suite; installing the core Studio does not silently replace Omarchy's
+native bar.
+
+<p align="center">
+  <img src="docs/product/assets/screenshots/bar-examples/bar-01-left-wide.png" width="850" alt="Wide bar placed toward the left">
+</p>
+<p align="center">
+  <img src="docs/product/assets/screenshots/bar-examples/bar-02-split-wide.png" width="850" alt="Wide split bar layout">
+</p>
+
+See the [full bar example gallery](docs/product/assets/screenshots/bar-examples/README.md)
+for all seven layouts, placement variants, and capture notes.
+
+## New v2 examples
+
+The v2 gallery pairs each generated theme's source background with its clean
+desktop preview. These examples show the range of compositions Omagen can
+produce from very different images.
+
+| Theme | Source background | Generated preview |
+| --- | --- | --- |
+| Elastic Example | <img src="assets/examples/v2/elastic-example-background.webp" alt="Elastic Example source background" width="300"> | <img src="assets/examples/v2/elastic-example-preview.webp" alt="Elastic Example generated preview" width="300"> |
+| Gothic Example | <img src="assets/examples/v2/gothic-example-background.webp" alt="Gothic Example source background" width="300"> | <img src="assets/examples/v2/gothic-example-preview.webp" alt="Gothic Example generated preview" width="300"> |
+| Japan Example | <img src="assets/examples/v2/japan-example-background.webp" alt="Japan Example source background" width="300"> | <img src="assets/examples/v2/japan-example-preview.webp" alt="Japan Example generated preview" width="300"> |
+| Nature Example | <img src="assets/examples/v2/nature-example-background.webp" alt="Nature Example source background" width="300"> | <img src="assets/examples/v2/nature-example-preview.webp" alt="Nature Example generated preview" width="300"> |
+| Retro Example | <img src="assets/examples/v2/retro-example-background.webp" alt="Retro Example source background" width="300"> | <img src="assets/examples/v2/retro-example-preview.webp" alt="Retro Example generated preview" width="300"> |
+| Spectral Example | <img src="assets/examples/v2/spectral-example-background.webp" alt="Spectral Example source background" width="300"> | <img src="assets/examples/v2/spectral-example-preview.webp" alt="Spectral Example generated preview" width="300"> |
+
+See the [complete v2 example gallery](docs/product/examples/README.md), including the
+historical examples explicitly labeled **made with Omagen v1**.
+
+## Product documentation
+
+| Guide | What it covers |
+| --- | --- |
+| [Getting started](docs/product/getting-started.md) | Installation, first launch, and the shortest path to a theme. |
+| [Product workflow](docs/product/workflow.md) | Preview, Test live, Demo, Apply, Cancel, and Quit. |
+| [Capabilities and trust](docs/product/capabilities.md) | What Omagen can read, write, invoke, and preserve. |
+| [Recovery and rollback](docs/product/recovery.md) | Interrupted sessions, restoration, ownership, and safe removal. |
+| [Examples](docs/product/examples/README.md) | Curated v2 wallpaper/theme pairs and example metadata. |
+| [Demo materials](docs/product/demos/README.md) | Product walkthroughs and the capture plan for v2. |
+| [Asset catalog](docs/product/assets/README.md) | Screenshots, recordings, examples, and provenance notes. |
+| [Asset checklist](docs/product/ASSET-CHECKLIST.md) | Evidence still required before stable release. |
+| [v2.0.0 release notes](docs/product/release-notes/v2.0.0.md) | Release scope, upgrade notes, limitations, and verification status. |
+
+For implementation contracts, contributor setup, compatibility evidence, and
+maintainer release procedures, use the [developer documentation](docs/README.md)
+and [release process](docs/development/release-process.md).
+
+## Trust boundary and capabilities
+
+Omagen is unsandboxed user-level plugin code. It can read the image and Omarchy
+configuration you select, write generated themes and Omagen-owned session
+state, invoke its bundled backend and explicit user-level adapters, and
+interact with the current Omarchy/Hyprland session.
+
+It does not require `sudo`, install system packages, or configure privileged
+services. It does not own unrelated themes, shell configuration, backgrounds,
+plugins, or user files. Read the [capabilities and trust guide](docs/product/capabilities.md)
+before installing if you want the complete boundary.
+
+The marketplace preflight is a release gate and exact-commit evidence; it is
+not a security certification, endorsement, or guarantee. See the developer
+[security policy](SECURITY.md) and [release process](docs/development/release-process.md)
+for the maintainer-level details.

--- a/docs/product/ASSET-CHECKLIST.md
+++ b/docs/product/ASSET-CHECKLIST.md
@@ -5,7 +5,7 @@ kept as a useful baseline; replace or supplement it deliberately after each
 new capture is reviewed. Do not delete the current gallery until replacement
 assets have been selected and all links have been updated.
 
-## Required before the stable `main` promotion
+## Stable snapshot status
 
 | Item | Suggested location | What to produce | Status |
 | --- | --- | --- | --- |
@@ -31,18 +31,22 @@ assets have been selected and all links have been updated.
 5. An interrupted Apply/recovery clip or still sequence.
 6. A before/after desktop pair using the same source wallpaper.
 
-## Remaining evidence before stable release
+## Remaining evidence before marketplace submission
 
-The maintainer considers the current live-desktop evidence sufficient for the
-v2 product presentation. The following release records still need to be
-attached to the exact stable commit:
+The stable v2 product snapshot is now in `main` at
+`92ff73ac17211755dd6790a89519371717eaeacf`, tagged `v2.0.0`. The maintainer
+considers the current live-desktop evidence sufficient for the v2 product
+presentation. The following records still need to be attached before
+marketplace submission:
 
 - At least five independent installations, two upgrades, and one interrupted
   session recovery run across the supported Omarchy versions.
 - Asset-license and redistribution confirmation recorded in
   [`assets/PROVENANCE.md`](assets/PROVENANCE.md).
-- Final marketplace preview and preflight report bound to the immutable stable
-  `main` SHA.
+- Final marketplace preview and the `review-required`, zero-finding preflight
+  report bound to the immutable stable `main` SHA. The report is uploaded as
+  the `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf` artifact
+  on the [exact-main CI run](https://github.com/prettyletto/omagen/actions/runs/33668731439).
 
 ## Capture rules
 

--- a/docs/product/assets/PROVENANCE.md
+++ b/docs/product/assets/PROVENANCE.md
@@ -7,7 +7,7 @@ use locally.
 
 ## Release rule
 
-Before the `dev → main` promotion, a maintainer must confirm that every asset
+Before marketplace submission, a maintainer must confirm that every asset
 copied into the stable repository may be redistributed under the repository's
 license or under the asset's documented license. Record the source, creator,
 license, and permission evidence in this file or in an adjacent notice. Do not
@@ -45,13 +45,21 @@ The historical gallery remains labeled “made with Omagen v1”. It should be
 reviewed by the same process before being treated as a redistributable release
 asset.
 
-## Maintainer completion record
+## Marketplace handoff completion record
 
-Fill this section before stable release; do not replace these fields with
-guesses.
+Complete this section before marketplace submission; do not replace these
+fields with guesses.
 
 - Reviewer: `TBD`
 - Review date: `TBD`
 - Asset sources and licenses recorded: `TBD`
 - Permission evidence linked: `TBD`
 - Unlicensed or uncertain assets removed from the stable package: `TBD`
+
+## Stable snapshot verification
+
+- Stable commit: `92ff73ac17211755dd6790a89519371717eaeacf`
+- Release tag: `v2.0.0`
+- Marketplace preflight: `review-required`, zero findings
+- Preflight artifact: `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf`
+- CI run: <https://github.com/prettyletto/omagen/actions/runs/33668731439>

--- a/docs/product/assets/README.md
+++ b/docs/product/assets/README.md
@@ -52,9 +52,10 @@ capture goals, dimensions, and provenance required before the stable release.
 The [provenance ledger](PROVENANCE.md) records the source and release status
 of the current branding, screenshots, recordings, and example pairs.
 
-Before promotion, every referenced asset must be present in the exact commit,
-have a reviewable license/provenance, and stay within the marketplace preview
-limits when used as a listing preview.
+Before marketplace submission or any later stable asset update, every
+referenced asset must be present in the exact commit, have reviewable
+license/provenance, and stay within the marketplace preview limits when used as
+a listing preview.
 
 ## Setup walkthrough screenshots
 

--- a/docs/product/release-notes/v2.0.0.md
+++ b/docs/product/release-notes/v2.0.0.md
@@ -1,8 +1,6 @@
 # Omagen v2.0.0
 
-> Release candidate notes. The product scope is complete; the verification
-> record remains open until the exact `main` commit has been tagged and
-> reviewed.
+> Stable release notes for the exact `main` snapshot tagged `v2.0.0`.
 
 Omagen v2 turns the original image-to-theme idea into a reversible desktop
 studio. It helps you explore a visual direction, test it in context, and keep
@@ -60,20 +58,24 @@ mutable branch or unpinned installation can differ from the reviewed commit.
 
 ## Verification record
 
-The fields below are intentionally explicit placeholders. They must be filled
-from the release commit and attached test evidence; do not infer them from a
-branch name or from an older marketplace report.
+This record is bound to the immutable stable snapshot. The marketplace report
+is a deterministic baseline check, not a security certification or endorsement.
 
-- Stable commit: `TBD — fill after dev → main promotion`
+- Stable commit: `92ff73ac17211755dd6790a89519371717eaeacf`
 - Release tag: `v2.0.0`
-- Marketplace preflight: `TBD — exact stable commit required`
-- Live-desktop evidence: `Maintainer-confirmed sufficient; attach exact capture
-  dates, versions, and SHAs`
-- Known working Omarchy versions: `4.0.1-1`, `4.0.2-1` (maintainer-confirmed;
-  attach exact dates and SHAs)
-- Independent installations: `TBD — target at least five`
-- Upgrade runs: `TBD — target at least two`
-- Interrupted-session recovery: `TBD — target at least one`
+- Marketplace preflight: `review-required`, with zero findings, for both
+  `pretty.omagen` and `pretty.omagen.bar`; see the [exact-main CI run](https://github.com/prettyletto/omagen/actions/runs/33668731439)
+  and artifact `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf`.
+- Live-desktop evidence: Maintainer-confirmed sufficient for the v2 product
+  presentation. No new live-desktop test was run by this automation.
+- Known working Omarchy versions: `4.0.1-1` and `4.0.2-1`, as confirmed by the
+  maintainer.
+- Independent installations: Release-specific records are not stored in this
+  repository; attach at least five exact records before marketplace submission.
+- Upgrade runs: Release-specific records are not stored in this repository;
+  attach at least two exact records before marketplace submission.
+- Interrupted-session recovery: Release-specific record is not stored in this
+  repository; attach at least one exact record before marketplace submission.
 
 For maintainer-only build provenance, security findings, and live-validation
 evidence, see the [developer release process](../../development/release-process.md)

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,9 +1,8 @@
 # Omagen v2.0.0 release notes
 
-This is the release-notes draft for the `dev → main` promotion. The final
-release must replace the placeholder commit and validation fields with the
-exact stable `main` SHA, tag, artifact hashes, live-desktop evidence, and
-marketplace preflight report.
+This release records the exact stable `main` snapshot promoted through
+`nightly → dev → main`. Marketplace verification remains a separate exact-
+commit maintainer handoff.
 
 ## What is included
 
@@ -56,12 +55,19 @@ see the stable `main` README for the user-facing removal choice.
 
 ## Verification record
 
-- Stable commit: `TBD — fill after dev → main merge`
+- Stable commit: `92ff73ac17211755dd6790a89519371717eaeacf`
 - Release tag: `v2.0.0`
-- Marketplace preflight report: `TBD — exact stable commit required`
-- Marketplace outcome: `TBD — passed or maintainer-approved review-required`
-- Omarchy `4.0.2-1`: `Maintainer-confirmed; attach exact test evidence`
-- Omarchy `4.0.1-1`: `Maintainer-confirmed; attach exact test evidence`
-- Independent installations: `TBD — at least five`
-- Upgrade runs: `TBD — at least two`
-- Interrupted-session recovery: `TBD — at least one`
+- Marketplace preflight report: `review-required`, zero findings, both plugin
+  IDs; see the [exact-main CI run](https://github.com/prettyletto/omagen/actions/runs/33668731439)
+  and artifact `marketplace-preflight-92ff73ac17211755dd6790a89519371717eaeacf`.
+- Marketplace maintainer review: Pending submission by the maintainer.
+- Omarchy `4.0.2-1`: Maintainer-confirmed supported version; attach the exact
+  test record during marketplace submission.
+- Omarchy `4.0.1-1`: Maintainer-confirmed supported version; attach the exact
+  test record during marketplace submission.
+- Independent installations: At least five release-specific records still
+  need to be attached by the maintainer.
+- Upgrade runs: At least two release-specific records still need to be
+  attached by the maintainer.
+- Interrupted-session recovery: At least one release-specific record still
+  needs to be attached by the maintainer.


### PR DESCRIPTION
## Summary

Synchronize the stable product documentation with the canonical release-evidence
record now present on `dev`.

- Current dev source: `158d225e291e043707ae1619f4a81f9494becdf7`
- Stable tag: `v2.0.0` remains immutable at `92ff73ac17211755dd6790a89519371717eaeacf`
- This is a documentation-only follow-up; no product code changes are included.
- Marketplace submission remains a maintainer action after the remaining exact
  installation, upgrade, recovery, and asset-rights records are attached.
