### PR TITLE
fix: keep overlay cancellation and full bar loadable

### DIFF
--- a/docs/architecture/product-boundaries.md
+++ b/docs/architecture/product-boundaries.md
@@ -26,6 +26,7 @@ Omarchy, and the runtime adapters meet through explicit data/protocol seams.
   assets, and the `bar/BarSizing.js` helper used by the overlay.
 - `~/.config/omarchy/plugins/pretty.omagen.bar/` contains the full-Bar entry
   point, Bar host files, `bar/` presets/widgets, the maintained Quattro clone,
-  and compiled shader assets.
+  its bounded `qml/services/BoundedOutputParser.qml` dependency, and compiled
+  shader assets.
 
 Neither manifest may absorb the other product's entry point or ownership.

--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,8 @@ for destination in \
     "$BAR_DEST_DIR/NativeBarClone.qml" \
     "$BAR_DEST_DIR/WorkspacePresentation.qml" \
     "$BAR_DEST_DIR/BarModel.js" \
+    "$BAR_DEST_DIR/qml" \
+    "$BAR_DEST_DIR/qml/services" \
     "$BAR_DEST_DIR/glitch.frag.qsb" \
     "$BAR_DEST_DIR/glitch.vert.qsb"; do
     if [[ -L "$destination" ]]; then
@@ -172,6 +174,14 @@ cp "$SRC_DIR/WorkspacePresentation.qml" "$BAR_DEST_DIR/WorkspacePresentation.qml
 cp "$SRC_DIR/BarModel.js" "$BAR_DEST_DIR/BarModel.js"
 rm -rf "$BAR_DEST_DIR/bar"
 cp -a "$SRC_DIR/bar" "$BAR_DEST_DIR/bar"
+# The full-bar plugin is installed independently from pretty.omagen, so it
+# must carry the service used by NativeBarClone and bar/CustomCommandModule.
+# Keep the payload minimal rather than merging the overlay's qml tree or
+# manifests.
+rm -rf "$BAR_DEST_DIR/qml"
+mkdir -p "$BAR_DEST_DIR/qml/services"
+cp "$SRC_DIR/qml/services/BoundedOutputParser.qml" \
+    "$BAR_DEST_DIR/qml/services/BoundedOutputParser.qml"
 cp "$SRC_DIR/qml/components/glitch.frag.qsb" "$BAR_DEST_DIR/glitch.frag.qsb"
 cp "$SRC_DIR/qml/components/glitch.vert.qsb" "$BAR_DEST_DIR/glitch.vert.qsb"
 

--- a/qml/controllers/LiveCanvasWizardController.qml
+++ b/qml/controllers/LiveCanvasWizardController.qml
@@ -159,13 +159,17 @@ Item {
     function cancelWorkflow() {
         if (!root.workflowStepActive)
             return false
-        root.workflowCancelRequested()
+        // In the composition root this signal is wired back to
+        // cancelPreSessionWorkflow(), which calls this method again. Clear
+        // the active state before emitting so that close/Back cancellation
+        // cannot recurse while the signal is being delivered.
         root.workflowStepActive = false
         root.sourceImageSelected = false
         root.workflowMode = ""
         root.workflowModeConfirmed = false
         root.workflowContinuePending = false
         root.workflowHistoryAvailable = false
+        root.workflowCancelRequested()
         return true
     }
 

--- a/qml/tests/tst_LiveCanvasWizardController.qml
+++ b/qml/tests/tst_LiveCanvasWizardController.qml
@@ -15,10 +15,14 @@ TestCase {
     property bool workflowCancelRequested: false
     property bool workflowBackRequested: false
     property bool restoreAndCloseRequested: false
+    property bool cancelSignalSawInactiveWorkflow: false
 
     Connections {
         target: controller
-        function onWorkflowCancelRequested() { workflowCancelRequested = true }
+        function onWorkflowCancelRequested() {
+            workflowCancelRequested = true
+            cancelSignalSawInactiveWorkflow = !controller.workflowStepActive
+        }
         function onWorkflowBackRequested() { workflowBackRequested = true }
         function onRestoreAndCloseRequested() { restoreAndCloseRequested = true }
     }
@@ -32,6 +36,7 @@ TestCase {
         workflowCancelRequested = false
         workflowBackRequested = false
         restoreAndCloseRequested = false
+        cancelSignalSawInactiveWorkflow = false
         controller.selectedVariant = "source"
         controller.selectedLookFeelPreset = "omarchy-native"
         controller.restoreFromFirstStep = false
@@ -141,6 +146,17 @@ TestCase {
         verify(controller.canGoBack)
         verify(controller.goBack())
         verify(workflowCancelRequested)
+    }
+
+    function test_cancelWorkflowInvalidatesBeforeEmittingCancellation() {
+        controller.beginWorkflow(true)
+
+        verify(controller.cancelWorkflow())
+        verify(cancelSignalSawInactiveWorkflow)
+        verify(!controller.workflowStepActive)
+        verify(!controller.sourceImageSelected)
+        compare(controller.workflowMode, "")
+        verify(!controller.workflowModeConfirmed)
     }
 
     function test_workflowContinueIsSingleFlightAndCanRetryAfterFailure() {

--- a/scripts/test-install-command.sh
+++ b/scripts/test-install-command.sh
@@ -44,6 +44,10 @@ USER_THEME_SET="$XDG_BIN_HOME/omagen-theme-set"
   printf 'full-bar manifest was not installed\n' >&2
   exit 1
 }
+[[ -f "$XDG_CONFIG_HOME/omarchy/plugins/pretty.omagen.bar/qml/services/BoundedOutputParser.qml" ]] || {
+  printf 'full-bar QML service dependency was not installed\n' >&2
+  exit 1
+}
 [[ "$(sed -n '1,2p' "$USER_THEME_SET")" == $'#!/usr/bin/env bash\n# Omagen user-facing theme activation adapter' ]] || {
   printf 'user dispatcher ownership marker missing\n' >&2
   exit 1


### PR DESCRIPTION
## Summary
- prevent pre-session overlay cancellation from recursing when an image is selected
- package the bounded output parser required by the standalone pretty.omagen.bar plugin
- add installer and controller regression coverage

## Verification
- `GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh`
- live `dev-install.sh --skip-build`
- verified `pretty-omagen-bar` surfaces on both monitors after reinstall

Promotes the focused fix from nightly toward dev.