### PR TITLE
Promote v2.0.0 product snapshot to main

### DIFF
--- a/.github/release-provenance.json
+++ b/.github/release-provenance.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "policyVersion": "product-docs-projection-v1",
+  "sourceBranch": "dev",
+  "sourceSha": "e0d46bf7bc09cea344a60204e5480a45d9353346",
+  "releaseVersion": "v2.0.0",
+  "generatedFiles": [
+    "README.md"
+  ],
+  "generatedAt": "2026-09-04T20:14:33.784876Z"
+}

--- a/README.md
+++ b/README.md
@@ -1,99 +1,192 @@
-# Omagen development branch
+<!-- omagen-product-readme: canonical-source -->
+![Omagen wordmark](docs/product/assets/branding/omagen-wordmark.png)
 
-This checkout is the `nightly` branch, intended for contributors and testers.
-It may contain incomplete or experimental work and must not be used as the
-normal user installation source. The controlled promotion path is:
+<div align="center">
 
-```text
-nightly → dev → main → marketplace verification
+# Omagen
+
+**Turn an image into an Omarchy desktop that feels like yours.**
+
+Generate a complete theme, explore meaningful variations, preview the result
+without committing to it, and apply it safely when it feels right.
+
+[![Build](https://img.shields.io/github/actions/workflow/status/prettyletto/omagen/verify-bundled-backend.yml?branch=main&style=flat-square&label=build)](https://github.com/prettyletto/omagen/actions)
+[![Documentation](https://img.shields.io/badge/docs-product%20guide-5b8def?style=flat-square)](docs/product/README.md)
+[![License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](LICENSE)
+
+[Get started](#get-started) · [See the workflow](#the-omagen-workflow) · [Browse examples](docs/product/examples/README.md) · [Read the product docs](#product-documentation)
+
+</div>
+
+![Omagen workflow preview](docs/product/assets/demos/omagen-demo-v2.gif)
+
+## Get started
+
+Omagen is built for Omarchy Quattro with Hyprland and Quickshell on Linux
+x86_64. Install the stable repository through Omarchy's plugin manager:
+
+```sh
+omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes
 ```
 
-The `dev` branch is the protected integration and release-candidate branch.
-The `main` branch owns the stable product README, demos, screenshots, user
-installation, upgrade, recovery, and release notes. See the [stable product
-README](https://github.com/prettyletto/omagen/blob/main/README.md) for the
-user-facing experience.
+Then open Omagen from the Omarchy launcher, choose a local image, review a
+palette direction, and use **Preview** or **Demo** before selecting **Apply**.
+The [getting started guide](docs/product/getting-started.md) covers requirements, first
+launch, optional applications, and removal.
 
-## Contributor setup
+To remove the packages later:
 
-Omagen is an Omarchy Quattro plugin composed of two separately owned packages:
-
-- `pretty.omagen` — the overlay and launcher/status widget.
-- `pretty.omagen.bar` — the optional full-bar plugin.
-
-Runtime requirements are Omarchy Quattro, Hyprland, Quickshell, and Linux
-x86_64 for the bundled backend executable. Demo applications are optional and
-are resolved with fallbacks. The plugin is unsandboxed and can modify the
-user-level themes, settings, shell state, backgrounds, and Omagen-owned
-session resources described in the [architecture](docs/architecture/README.md).
-It does not require `sudo`, install system packages, or configure privileged
-services.
-
-Clone the repository and install the current checkout locally:
-
-```zsh
-git clone https://github.com/prettyletto/omagen.git
-cd omagen
-./dev-install.sh
-```
-
-For tester or release-candidate validation, inspect an immutable full commit
-before installing it. The bootstrap refuses a mutable branch head:
-
-```zsh
-git clone https://github.com/prettyletto/omagen.git /tmp/omagen-review
-cd /tmp/omagen-review
-git show --stat --oneline <full-40-character-commit-sha>
-OMAGEN_TEST_BRANCH=nightly \
-OMAGEN_TEST_COMMIT=<full-40-character-commit-sha> \
-  ./scripts/install-branch.sh
-```
-
-Run the local repository gate from zsh:
-
-```zsh
-GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh
-python3 scripts/marketplace-preflight.py \
-  --commit "$(git rev-parse HEAD)" \
-  --report /tmp/omagen-marketplace-report.json
-```
-
-The preflight is deterministic, read-only, and never executes plugin code or
-downloaded content. It scans both manifests source-wide, checks the root
-packaging contract, records capabilities and findings against the exact commit,
-and returns `passed`, `review-required`, or `needs-fixes`.
-
-## Developer documentation
-
-- [Development guide](docs/development.md) — local setup, tests, packaging,
-  QML validation, and the repository gate.
-- [Release and promotion process](docs/development/release-process.md) —
-  branch contracts, candidate states, exact-commit evidence, and marketplace
-  submission.
-- [Architecture](docs/architecture/README.md) — plugin boundaries, the
-  QML/backend contract, generation, lifecycle, and recovery ownership.
-- [Demo workspace](docs/demo.md) — implementation and ownership contracts for
-  the temporary Demo paths.
-- [Contributing](CONTRIBUTING.md) — pull requests, reviews, and validation
-  expectations.
-- [Security policy](SECURITY.md) — trust boundaries and vulnerability reports.
-
-## Removal during development
-
-From a local checkout, run:
-
-```zsh
-./uninstall.sh
-```
-
-The uninstaller recovers an active Omagen session and preserves permanent
-themes, unrelated plugins, and resources without Omagen ownership markers.
-For package-only removal, use the native plugin manager explicitly:
-
-```zsh
+```sh
 omarchy plugin remove pretty.omagen --yes
 omarchy plugin remove pretty.omagen.bar --yes
 ```
 
-The stable `main` branch must retain the user-facing installation and removal
-instructions in its own root README before the final release promotion.
+Removing the plugins does not delete permanent themes created by you. If an
+Omagen session is active, use its recovery or restore path before removing
+state manually.
+
+## What is Omagen?
+
+Omagen is an image-to-theme studio for [Omarchy Quattro](https://omarchy.org/).
+It turns the colors and atmosphere of a source image into a coherent desktop
+direction, then gives you a safe way to judge that direction before it becomes
+permanent.
+
+The experience is designed around a simple loop:
+
+```text
+image → palette directions → preview or Demo → apply or cancel
+```
+
+Omagen is one product suite with two technical plugin packages:
+
+- `pretty.omagen` provides the Studio overlay, image generation, previews,
+  Demo, lifecycle, recovery, and the launcher/status widget.
+- `pretty.omagen.bar` is the optional full-bar experience for users who want
+  Omagen's Bar presets and behavior as their active bar.
+
+They remain separate because Omarchy registers overlays/widgets and full bars
+as different plugin kinds. They are presented as one suite, but the full bar
+is explicit and opt-in so installing Omagen does not silently replace the
+native Quattro bar.
+
+## Why Omagen?
+
+- Start from an image you already like instead of tuning colors from scratch.
+- Compare six generated directions: Source, Calm, Mute, Deep, Vibrant, and
+  Balanced.
+- Preview Window, Shell, Bar, and Animation choices in context when you want
+  more than a palette.
+- Open a temporary Demo workspace to judge the theme across real desktop
+  surfaces.
+- Apply a named theme only when you are satisfied—or Cancel and leave the
+  current desktop unchanged.
+- Recover an interrupted session through the durable session record instead of
+  guessing which temporary files are safe to remove.
+
+## The Omagen workflow
+
+### 1. Choose an image
+
+Choose a local image in a common raster format. Omagen extracts representative
+colors and keeps the selected image as the visual source for the session.
+
+### 2. Explore directions
+
+Review six palette directions generated by the same production pipeline used by
+the applied theme. The gallery is meant to help you choose a mood, not just a
+single dominant color.
+
+### 3. Preview safely
+
+Use Live Canvas to inspect the staged result. Use **Test live** for a reversible
+desktop preview, or open **Demo** to see the composition across a temporary
+editor, terminal, system monitor, and file manager workspace.
+
+### 4. Apply or cancel
+
+**Apply** writes a named permanent theme after the staged session is ready.
+**Cancel** restores the original theme, background, and Omagen-owned temporary
+resources. **Quit** uses the same recovery path when a session is active.
+
+### 5. Recover when interrupted
+
+If Omagen or the shell is interrupted during a preview or Apply, the next
+launch presents an explicit recovery choice. Restore the original desktop or
+resume the staged workspace when it can still be verified safely.
+
+## See it in action
+
+[![Watch the Omagen walkthrough](docs/product/assets/social/omagen-walkthrough-thumbnail-v2.png)](https://youtu.be/juDJe0zWwZI)
+
+Watch the [full Omagen walkthrough on YouTube](https://youtu.be/juDJe0zWwZI)
+for the image-to-theme flow, preview paths, Demo, and Apply experience.
+
+## Bar examples
+
+Here are a few examples of the optional Omagen bar direction across different
+placements and information densities. The full bar is an opt-in part of the
+Omagen suite; installing the core Studio does not silently replace Omarchy's
+native bar.
+
+<p align="center">
+  <img src="docs/product/assets/screenshots/bar-examples/bar-01-left-wide.png" width="850" alt="Wide bar placed toward the left">
+</p>
+<p align="center">
+  <img src="docs/product/assets/screenshots/bar-examples/bar-02-split-wide.png" width="850" alt="Wide split bar layout">
+</p>
+
+See the [full bar example gallery](docs/product/assets/screenshots/bar-examples/README.md)
+for all seven layouts, placement variants, and capture notes.
+
+## New v2 examples
+
+The v2 gallery pairs each generated theme's source background with its clean
+desktop preview. These examples show the range of compositions Omagen can
+produce from very different images.
+
+| Theme | Source background | Generated preview |
+| --- | --- | --- |
+| Elastic Example | <img src="assets/examples/v2/elastic-example-background.webp" alt="Elastic Example source background" width="300"> | <img src="assets/examples/v2/elastic-example-preview.webp" alt="Elastic Example generated preview" width="300"> |
+| Gothic Example | <img src="assets/examples/v2/gothic-example-background.webp" alt="Gothic Example source background" width="300"> | <img src="assets/examples/v2/gothic-example-preview.webp" alt="Gothic Example generated preview" width="300"> |
+| Japan Example | <img src="assets/examples/v2/japan-example-background.webp" alt="Japan Example source background" width="300"> | <img src="assets/examples/v2/japan-example-preview.webp" alt="Japan Example generated preview" width="300"> |
+| Nature Example | <img src="assets/examples/v2/nature-example-background.webp" alt="Nature Example source background" width="300"> | <img src="assets/examples/v2/nature-example-preview.webp" alt="Nature Example generated preview" width="300"> |
+| Retro Example | <img src="assets/examples/v2/retro-example-background.webp" alt="Retro Example source background" width="300"> | <img src="assets/examples/v2/retro-example-preview.webp" alt="Retro Example generated preview" width="300"> |
+
+See the [complete v2 example gallery](docs/product/examples/README.md), including the
+historical examples explicitly labeled **made with Omagen v1**.
+
+## Product documentation
+
+| Guide | What it covers |
+| --- | --- |
+| [Getting started](docs/product/getting-started.md) | Installation, first launch, and the shortest path to a theme. |
+| [Product workflow](docs/product/workflow.md) | Preview, Test live, Demo, Apply, Cancel, and Quit. |
+| [Capabilities and trust](docs/product/capabilities.md) | What Omagen can read, write, invoke, and preserve. |
+| [Recovery and rollback](docs/product/recovery.md) | Interrupted sessions, restoration, ownership, and safe removal. |
+| [Examples](docs/product/examples/README.md) | Curated v2 wallpaper/theme pairs and example metadata. |
+| [Demo materials](docs/product/demos/README.md) | Product walkthroughs and the capture plan for v2. |
+| [Asset catalog](docs/product/assets/README.md) | Screenshots, recordings, examples, and provenance notes. |
+| [Asset checklist](docs/product/ASSET-CHECKLIST.md) | Evidence still required before stable release. |
+| [v2.0.0 release notes](docs/product/release-notes/v2.0.0.md) | Release scope, upgrade notes, limitations, and verification status. |
+
+For implementation contracts, contributor setup, compatibility evidence, and
+maintainer release procedures, use the [developer documentation](docs/README.md)
+and [release process](docs/development/release-process.md).
+
+## Trust boundary and capabilities
+
+Omagen is unsandboxed user-level plugin code. It can read the image and Omarchy
+configuration you select, write generated themes and Omagen-owned session
+state, invoke its bundled backend and explicit user-level adapters, and
+interact with the current Omarchy/Hyprland session.
+
+It does not require `sudo`, install system packages, or configure privileged
+services. It does not own unrelated themes, shell configuration, backgrounds,
+plugins, or user files. Read the [capabilities and trust guide](docs/product/capabilities.md)
+before installing if you want the complete boundary.
+
+The marketplace preflight is a release gate and exact-commit evidence; it is
+not a security certification, endorsement, or guarantee. See the developer
+[security policy](SECURITY.md) and [release process](docs/development/release-process.md)
+for the maintainer-level details.

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,8 +123,9 @@ OMAGEN_TEST_BRANCH=nightly OMAGEN_TEST_COMMIT=<full-40-character-commit-sha> \
 The bootstrap refuses to execute a mutable branch head. It initializes an
 empty checkout, fetches only the requested full commit, checks it out detached,
 and only then runs `dev-install.sh --skip-build`. `OMAGEN_TEST_COMMIT` is the
-source-of-truth selector; `OMAGEN_TEST_BRANCH` is retained as an informational
-tester hint, while `OMAGEN_TEST_REPOSITORY` selects a different fork.
+source-of-truth selector and `OMAGEN_TEST_BRANCH` is retained only as an
+informational tester hint. This marketplace-scanned bootstrap intentionally
+fetches the Omagen repository itself; test a fork from a separate checkout.
 
 The regular `install.sh` still builds the backend by default. Pass
 `--skip-build` only when the checked-in binary is the intended artifact, as in

--- a/scripts/install-branch.sh
+++ b/scripts/install-branch.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# This script installs a tester-selected, exact commit. It deliberately refuses
-# to execute a mutable branch head, so the caller can inspect the commit before
-# running the installer.
-REPOSITORY="${OMAGEN_TEST_REPOSITORY:-https://github.com/prettyletto/omagen.git}"
+# This script installs a tester-selected, exact commit from the Omagen
+# repository. It deliberately refuses to execute a mutable branch head, so the
+# caller can inspect the commit before running the installer. Fork testing is
+# intentionally outside this marketplace-scanned bootstrap.
 # Retain the branch input for compatibility with existing tester commands. It
 # is informational only; it must never select the source that gets executed.
 BRANCH="${OMAGEN_TEST_BRANCH:-nightly}"
@@ -16,7 +16,7 @@ Usage: OMAGEN_TEST_COMMIT=<full-sha> $0
 
 The exact commit is required before any checked-out code is executed:
   OMAGEN_TEST_COMMIT=<40-character-sha>
-  OMAGEN_TEST_BRANCH=<branch> OMAGEN_TEST_REPOSITORY=<url> $0
+  OMAGEN_TEST_BRANCH=<branch> $0
 EOF
 }
 
@@ -47,8 +47,8 @@ trap cleanup EXIT
 checkout="$checkout_root/source"
 echo "Fetching Omagen commit $COMMIT (branch hint '$BRANCH' is informational only)..."
 git init --quiet "$checkout"
-git -C "$checkout" remote add origin "$REPOSITORY"
-git -C "$checkout" fetch --depth 1 origin "$COMMIT"
+git -C "$checkout" remote add origin https://github.com/prettyletto/omagen.git
+git -C "$checkout" fetch --depth 1 https://github.com/prettyletto/omagen.git "$COMMIT"
 git -C "$checkout" checkout --detach "$COMMIT"
 actual_commit="$(git -C "$checkout" rev-parse HEAD)"
 [[ "$actual_commit" == "$COMMIT" ]] || {


### PR DESCRIPTION
## Controlled product promotion

This pull request was generated from the exact dev commit `e0d46bf7bc09cea344a60204e5480a45d9353346`.

It contains the marketplace tester bootstrap fix and the generated stable documentation projection. Stable CI must verify the recorded dev SHA, documentation projection, package checks, and marketplace preflight before merge.

Promotion workflow: https://github.com/prettyletto/omagen/actions/runs/33915226808