### PR TITLE
ci: enforce repository history file budget

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,6 +43,17 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Test repository history policy
+        run: scripts/test-large-file-deltas.sh
+
+      - name: Enforce repository history policy
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: scripts/check-large-file-deltas.sh "$BASE_SHA" "$HEAD_SHA"
 
       - name: Install documentation tooling
         run: |

--- a/docs/development.md
+++ b/docs/development.md
@@ -91,6 +91,21 @@ pushes to those protected branches. A binary change without a matching source
 build fails the check. Candidate and stable commits also receive the
 marketplace-preflight report described in [the release process](development/release-process.md).
 
+## Repository history budget
+
+The plugin package intentionally carries the current `bin/omagen` and
+`bin/omagen-studio` executables because users must be able to install and run
+Omagen without a Go toolchain. Those two paths are the only large-file
+exceptions in the repository history policy; the bundled-backend verifier still
+requires each executable to match a deterministic build from `backend/`.
+
+New or modified non-runtime files over 5 MiB are rejected on pull requests
+targeting `dev` or `main`. Large walkthrough videos, GIFs, screenshots, and
+other documentation media belong in release or documentation hosting rather
+than the plugin Git history. Removing a file in a later commit does not remove
+its old Git objects, so a history cleanup is an explicit maintenance operation
+and not a substitute for this forward-looking policy.
+
 The root <code>preview.png</code> is a marketplace showcase image. It is not a
 runtime entry point and is not required by the Omarchy shell loader; the
 community marketplace can resize and optimize it for plugin listings.

--- a/scripts/check-large-file-deltas.sh
+++ b/scripts/check-large-file-deltas.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+REPOSITORY_ROOT="${OMAGEN_POLICY_REPOSITORY_ROOT:-$SCRIPT_ROOT}"
+MAX_BYTES="${OMAGEN_MAX_NEW_NONRUNTIME_FILE_BYTES:-5242880}"
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    printf 'Usage: %s <base-commit> <head-commit>\n' "${0##*/}" >&2
+    exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+BASE="$1"
+HEAD="$2"
+
+[[ "$MAX_BYTES" =~ ^[0-9]+$ ]] || fail "OMAGEN_MAX_NEW_NONRUNTIME_FILE_BYTES must be an integer"
+(( MAX_BYTES > 0 )) || fail "maximum file size must be positive"
+git -C "$REPOSITORY_ROOT" rev-parse --verify "$BASE^{commit}" >/dev/null || fail "base commit is not available: $BASE"
+git -C "$REPOSITORY_ROOT" rev-parse --verify "$HEAD^{commit}" >/dev/null || fail "head commit is not available: $HEAD"
+
+is_runtime_binary() {
+    case "$1" in
+        bin/omagen|bin/omagen-studio)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+format_bytes() {
+    numfmt --to=iec-i --suffix=B "$1" 2>/dev/null || printf '%s bytes' "$1"
+}
+
+violations=()
+while IFS= read -r -d '' path; do
+    is_runtime_binary "$path" && continue
+
+    size="$(git -C "$REPOSITORY_ROOT" cat-file -s "$HEAD:$path")"
+    if (( size > MAX_BYTES )); then
+        violations+=("$path ($(format_bytes "$size"), limit $(format_bytes "$MAX_BYTES"))")
+    fi
+done < <(git -C "$REPOSITORY_ROOT" diff --no-renames --name-only --diff-filter=ACM -z "$BASE" "$HEAD" --)
+
+if (( ${#violations[@]} > 0 )); then
+    printf 'New or modified non-runtime files exceed the repository history budget:\n' >&2
+    printf '  - %s\n' "${violations[@]}" >&2
+    printf '\nMove large media to release/documentation hosting or reduce it before merging.\n' >&2
+    exit 1
+fi
+
+printf 'Large-file policy passed (non-runtime limit: %s).\n' "$(format_bytes "$MAX_BYTES")"

--- a/scripts/test-large-file-deltas.sh
+++ b/scripts/test-large-file-deltas.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/omagen-large-file-policy.XXXXXXXX")"
+trap 'rm -rf -- "$TEMP_ROOT"' EXIT
+
+git -C "$TEMP_ROOT" init -q
+git -C "$TEMP_ROOT" config user.email test@example.invalid
+git -C "$TEMP_ROOT" config user.name "Omagen Large File Policy"
+
+printf 'small\n' >"$TEMP_ROOT/README.md"
+git -C "$TEMP_ROOT" add README.md
+git -C "$TEMP_ROOT" commit -qm baseline
+base="$(git -C "$TEMP_ROOT" rev-parse HEAD)"
+
+dd if=/dev/zero of="$TEMP_ROOT/oversized.dat" bs=1M count=6 status=none
+git -C "$TEMP_ROOT" add oversized.dat
+git -C "$TEMP_ROOT" commit -qm oversized
+head="$(git -C "$TEMP_ROOT" rev-parse HEAD)"
+if OMAGEN_POLICY_REPOSITORY_ROOT="$TEMP_ROOT" "$ROOT/scripts/check-large-file-deltas.sh" "$base" "$head"; then
+    printf 'FAIL: oversized non-runtime file was accepted\n' >&2
+    exit 1
+fi
+
+git -C "$TEMP_ROOT" rm -q oversized.dat
+git -C "$TEMP_ROOT" commit -qm "remove oversized fixture"
+base="$(git -C "$TEMP_ROOT" rev-parse HEAD)"
+mkdir -p "$TEMP_ROOT/bin"
+dd if=/dev/zero of="$TEMP_ROOT/bin/omagen" bs=1M count=6 status=none
+git -C "$TEMP_ROOT" add bin/omagen
+git -C "$TEMP_ROOT" commit -qm "add allowed runtime fixture"
+head="$(git -C "$TEMP_ROOT" rev-parse HEAD)"
+OMAGEN_POLICY_REPOSITORY_ROOT="$TEMP_ROOT" "$ROOT/scripts/check-large-file-deltas.sh" "$base" "$head"
+
+printf 'Large-file policy tests passed.\n'


### PR DESCRIPTION
## Summary
- add a 5 MiB policy for new or modified non-runtime files on dev/main PRs
- preserve the required bundled backend executables as explicit exceptions
- add a focused policy self-test and document the future history-budget contract

## Validation
- scripts/test-large-file-deltas.sh
- scripts/check-large-file-deltas.sh origin/dev HEAD
- bash -n scripts/check-large-file-deltas.sh scripts/test-large-file-deltas.sh
- git diff --check

This is the preparatory guardrail for the scoped history cleanup; it does not change the runtime binary or marketplace contracts.