### PR TITLE
fix: materialize full bar during production install

### DIFF
--- a/docs/architecture/product-boundaries.md
+++ b/docs/architecture/product-boundaries.md
@@ -26,6 +26,7 @@ Omarchy, and the runtime adapters meet through explicit data/protocol seams.
   assets, and the `bar/BarSizing.js` helper used by the overlay.
 - `~/.config/omarchy/plugins/pretty.omagen.bar/` contains the full-Bar entry
   point, Bar host files, `bar/` presets/widgets, the maintained Quattro clone,
-  and compiled shader assets.
+  its bounded `qml/services/BoundedOutputParser.qml` dependency, and compiled
+  shader assets.
 
 Neither manifest may absorb the other product's entry point or ownership.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -35,7 +35,7 @@ Omagen plugin packages:
 
 ```zsh
 omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
-  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only
 ```
 
 The first command installs and enables the Studio overlay. Omarchy's plugin
@@ -46,7 +46,8 @@ choose a full-bar preset in Omagen. The checked-in backend is used, so Go is not
 required.
 
 After updating the plugin with `omarchy plugin update pretty.omagen --yes`,
-run the installer command again to synchronize the full-bar package.
+run `"$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only`
+again to synchronize the full-bar package.
 
 Then open Omagen from the Omarchy launcher, choose a local image, review a
 palette direction, and use **Preview** or **Demo** before selecting **Apply**.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -29,11 +29,24 @@ without committing to it, and apply it safely when it feels right.
 ## Get started
 
 Omagen is built for Omarchy Quattro with Hyprland and Quickshell on Linux
-x86_64. Install the stable repository through Omarchy's plugin manager:
+x86_64. Install the stable repository through Omarchy's plugin manager, then
+run the bundled package installer once so the same repository materializes both
+Omagen plugin packages:
 
-```sh
-omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes
+```zsh
+omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
 ```
+
+The first command installs and enables the Studio overlay. Omarchy's plugin
+manager validates only the repository's root manifest, so the second command
+also installs the separate `pretty.omagen.bar` package from the same checkout.
+It does not select that bar; the native Quattro bar remains active until you
+choose a full-bar preset in Omagen. The checked-in backend is used, so Go is not
+required.
+
+After updating the plugin with `omarchy plugin update pretty.omagen --yes`,
+run the installer command again to synchronize the full-bar package.
 
 Then open Omagen from the Omarchy launcher, choose a local image, review a
 palette direction, and use **Preview** or **Demo** before selecting **Apply**.

--- a/docs/product/getting-started.md
+++ b/docs/product/getting-started.md
@@ -17,15 +17,22 @@ fallback is selected instead.
 
 ## Install
 
-Install the stable repository with Omarchy's plugin manager:
+Install the stable repository with Omarchy's plugin manager, then run the
+bundled package installer once:
 
-```sh
-omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes
+```zsh
+omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
 ```
 
-This installs the Omagen suite without requiring Go. The core overlay and the
-optional full-bar package remain separate in Omarchy's registry so the native
-Quattro bar is not replaced unexpectedly.
+The plugin manager installs the repository's root `pretty.omagen` package. The
+second command installs the separate `pretty.omagen.bar` package from the same
+repository checkout. This uses the checked-in backend, so Go is not required.
+The full-bar package is installed but not selected; the native Quattro bar
+remains active until you choose a full-bar preset in Omagen.
+
+After updating the plugin with `omarchy plugin update pretty.omagen --yes`, run
+the installer command again to synchronize the full-bar package.
 
 ## First launch
 

--- a/docs/product/getting-started.md
+++ b/docs/product/getting-started.md
@@ -22,7 +22,7 @@ bundled package installer once:
 
 ```zsh
 omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
-  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only
 ```
 
 The plugin manager installs the repository's root `pretty.omagen` package. The
@@ -32,7 +32,8 @@ The full-bar package is installed but not selected; the native Quattro bar
 remains active until you choose a full-bar preset in Omagen.
 
 After updating the plugin with `omarchy plugin update pretty.omagen --yes`, run
-the installer command again to synchronize the full-bar package.
+`"$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only` again to
+synchronize the full-bar package.
 
 ## First launch
 

--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,8 @@ for destination in \
     "$BAR_DEST_DIR/NativeBarClone.qml" \
     "$BAR_DEST_DIR/WorkspacePresentation.qml" \
     "$BAR_DEST_DIR/BarModel.js" \
+    "$BAR_DEST_DIR/qml" \
+    "$BAR_DEST_DIR/qml/services" \
     "$BAR_DEST_DIR/glitch.frag.qsb" \
     "$BAR_DEST_DIR/glitch.vert.qsb"; do
     if [[ -L "$destination" ]]; then
@@ -172,6 +174,14 @@ cp "$SRC_DIR/WorkspacePresentation.qml" "$BAR_DEST_DIR/WorkspacePresentation.qml
 cp "$SRC_DIR/BarModel.js" "$BAR_DEST_DIR/BarModel.js"
 rm -rf "$BAR_DEST_DIR/bar"
 cp -a "$SRC_DIR/bar" "$BAR_DEST_DIR/bar"
+# The full-bar plugin is installed independently from pretty.omagen, so it
+# must carry the service used by NativeBarClone and bar/CustomCommandModule.
+# Keep the payload minimal rather than merging the overlay's qml tree or
+# manifests.
+rm -rf "$BAR_DEST_DIR/qml"
+mkdir -p "$BAR_DEST_DIR/qml/services"
+cp "$SRC_DIR/qml/services/BoundedOutputParser.qml" \
+    "$BAR_DEST_DIR/qml/services/BoundedOutputParser.qml"
 cp "$SRC_DIR/qml/components/glitch.frag.qsb" "$BAR_DEST_DIR/glitch.frag.qsb"
 cp "$SRC_DIR/qml/components/glitch.vert.qsb" "$BAR_DEST_DIR/glitch.vert.qsb"
 

--- a/install.sh
+++ b/install.sh
@@ -23,22 +23,93 @@ done
 
 usage() {
     cat <<EOF
-Usage: $0 [--skip-build]
+Usage: $0 [--skip-build|--bar-only]
 
 Options:
   --skip-build  Install the checked-in backend binary without compiling Go.
+  --bar-only    Install or refresh only the separate full-bar package.
 EOF
 }
 
 BUILD_BACKEND=1
+BAR_ONLY=0
 
 for arg in "$@"; do
     case "$arg" in
         -h|--help) usage; exit 0 ;;
         --skip-build) BUILD_BACKEND=0 ;;
+        --bar-only) BAR_ONLY=1; BUILD_BACKEND=0 ;;
         *) usage >&2; exit 2 ;;
     esac
 done
+
+install_full_bar() {
+    if [[ "$SRC_DIR" == "$BAR_DEST_DIR" ]]; then
+        echo "Refusing to install the full bar from its own destination: $SRC_DIR" >&2
+        return 1
+    fi
+
+    # The full bar is a separate plugin kind. Keeping it separate from the
+    # bar-widget manifest is required by Quattro's registry: a manifest
+    # selected as the active bar is not also treated as a layout widget.
+    echo "Installing $BAR_PLUGIN_ID..."
+    if [[ -L "$BAR_DEST_DIR" ]]; then
+        echo "Refusing to install through symlinked plugin directory: $BAR_DEST_DIR" >&2
+        return 1
+    fi
+    mkdir -p "$BAR_DEST_DIR"
+    for destination in \
+        "$BAR_DEST_DIR/manifest.json" \
+        "$BAR_DEST_DIR/OmagenBar.qml" \
+        "$BAR_DEST_DIR/BarSurface.qml" \
+        "$BAR_DEST_DIR/BarMoveGhostPanel.qml" \
+        "$BAR_DEST_DIR/CyberpunkBarSignal.qml" \
+        "$BAR_DEST_DIR/NativeBarClone.qml" \
+        "$BAR_DEST_DIR/WorkspacePresentation.qml" \
+        "$BAR_DEST_DIR/BarModel.js" \
+        "$BAR_DEST_DIR/qml" \
+        "$BAR_DEST_DIR/qml/services" \
+        "$BAR_DEST_DIR/glitch.frag.qsb" \
+        "$BAR_DEST_DIR/glitch.vert.qsb"; do
+        if [[ -L "$destination" ]]; then
+            echo "Refusing to install through symlinked package path: $destination" >&2
+            return 1
+        fi
+    done
+    cp "$SRC_DIR/bar-manifest.json" "$BAR_DEST_DIR/manifest.json"
+    cp "$SRC_DIR/OmagenBar.qml" "$BAR_DEST_DIR/OmagenBar.qml"
+    cp "$SRC_DIR/BarSurface.qml" "$BAR_DEST_DIR/BarSurface.qml"
+    cp "$SRC_DIR/BarMoveGhostPanel.qml" "$BAR_DEST_DIR/BarMoveGhostPanel.qml"
+    cp "$SRC_DIR/CyberpunkBarSignal.qml" "$BAR_DEST_DIR/CyberpunkBarSignal.qml"
+    cp "$SRC_DIR/NativeBarClone.qml" "$BAR_DEST_DIR/NativeBarClone.qml"
+    cp "$SRC_DIR/WorkspacePresentation.qml" "$BAR_DEST_DIR/WorkspacePresentation.qml"
+    cp "$SRC_DIR/BarModel.js" "$BAR_DEST_DIR/BarModel.js"
+    rm -rf "$BAR_DEST_DIR/bar"
+    cp -a "$SRC_DIR/bar" "$BAR_DEST_DIR/bar"
+    # The full-bar plugin is installed independently from pretty.omagen, so it
+    # must carry the service used by NativeBarClone and bar/CustomCommandModule.
+    # Keep the payload minimal rather than merging the overlay's qml tree or
+    # manifests.
+    rm -rf "$BAR_DEST_DIR/qml"
+    mkdir -p "$BAR_DEST_DIR/qml/services"
+    cp "$SRC_DIR/qml/services/BoundedOutputParser.qml" \
+        "$BAR_DEST_DIR/qml/services/BoundedOutputParser.qml"
+    cp "$SRC_DIR/qml/components/glitch.frag.qsb" "$BAR_DEST_DIR/glitch.frag.qsb"
+    cp "$SRC_DIR/qml/components/glitch.vert.qsb" "$BAR_DEST_DIR/glitch.vert.qsb"
+
+    echo "Installed $BAR_PLUGIN_ID -> $BAR_DEST_DIR"
+}
+
+if ((BAR_ONLY)); then
+    install_full_bar
+    if omarchy-shell shell rescanPlugins; then
+        echo "Omarchy shell rescanned plugins."
+    else
+        echo "Omarchy shell is not running; rescan later with:"
+        echo "  omarchy-shell shell rescanPlugins"
+    fi
+    exit 0
+fi
 
 if ((BUILD_BACKEND)); then
     echo "Building Omagen backend..."
@@ -50,6 +121,12 @@ else
         exit 1
     }
     echo "Using checked-in Omagen backend (Go build skipped)."
+fi
+
+if [[ "$SRC_DIR" == "$DEST_DIR" ]]; then
+    echo "Refusing a full install from the installed overlay directory: $SRC_DIR" >&2
+    echo "Run this installer from an external checkout, or use --bar-only to refresh the full bar." >&2
+    exit 1
 fi
 
 echo "Installing Omagen..."
@@ -137,56 +214,8 @@ else
     echo "Installed user command: $USER_THEME_SET"
 fi
 
-# The full bar is a separate plugin kind. Keeping it separate from the
-# bar-widget manifest is required by Quattro's registry: a manifest selected
-# as the active bar is not also treated as a layout widget.
-echo "Installing $BAR_PLUGIN_ID..."
-if [[ -L "$BAR_DEST_DIR" ]]; then
-    echo "Refusing to install through symlinked plugin directory: $BAR_DEST_DIR" >&2
-    exit 1
-fi
-mkdir -p "$BAR_DEST_DIR"
-for destination in \
-    "$BAR_DEST_DIR/manifest.json" \
-    "$BAR_DEST_DIR/OmagenBar.qml" \
-    "$BAR_DEST_DIR/BarSurface.qml" \
-    "$BAR_DEST_DIR/BarMoveGhostPanel.qml" \
-    "$BAR_DEST_DIR/CyberpunkBarSignal.qml" \
-    "$BAR_DEST_DIR/NativeBarClone.qml" \
-    "$BAR_DEST_DIR/WorkspacePresentation.qml" \
-    "$BAR_DEST_DIR/BarModel.js" \
-    "$BAR_DEST_DIR/qml" \
-    "$BAR_DEST_DIR/qml/services" \
-    "$BAR_DEST_DIR/glitch.frag.qsb" \
-    "$BAR_DEST_DIR/glitch.vert.qsb"; do
-    if [[ -L "$destination" ]]; then
-        echo "Refusing to install through symlinked package path: $destination" >&2
-        exit 1
-    fi
-done
-cp "$SRC_DIR/bar-manifest.json" "$BAR_DEST_DIR/manifest.json"
-cp "$SRC_DIR/OmagenBar.qml" "$BAR_DEST_DIR/OmagenBar.qml"
-cp "$SRC_DIR/BarSurface.qml" "$BAR_DEST_DIR/BarSurface.qml"
-cp "$SRC_DIR/BarMoveGhostPanel.qml" "$BAR_DEST_DIR/BarMoveGhostPanel.qml"
-cp "$SRC_DIR/CyberpunkBarSignal.qml" "$BAR_DEST_DIR/CyberpunkBarSignal.qml"
-cp "$SRC_DIR/NativeBarClone.qml" "$BAR_DEST_DIR/NativeBarClone.qml"
-cp "$SRC_DIR/WorkspacePresentation.qml" "$BAR_DEST_DIR/WorkspacePresentation.qml"
-cp "$SRC_DIR/BarModel.js" "$BAR_DEST_DIR/BarModel.js"
-rm -rf "$BAR_DEST_DIR/bar"
-cp -a "$SRC_DIR/bar" "$BAR_DEST_DIR/bar"
-# The full-bar plugin is installed independently from pretty.omagen, so it
-# must carry the service used by NativeBarClone and bar/CustomCommandModule.
-# Keep the payload minimal rather than merging the overlay's qml tree or
-# manifests.
-rm -rf "$BAR_DEST_DIR/qml"
-mkdir -p "$BAR_DEST_DIR/qml/services"
-cp "$SRC_DIR/qml/services/BoundedOutputParser.qml" \
-    "$BAR_DEST_DIR/qml/services/BoundedOutputParser.qml"
-cp "$SRC_DIR/qml/components/glitch.frag.qsb" "$BAR_DEST_DIR/glitch.frag.qsb"
-cp "$SRC_DIR/qml/components/glitch.vert.qsb" "$BAR_DEST_DIR/glitch.vert.qsb"
-
 echo "Installed $PLUGIN_ID -> $DEST_DIR"
-echo "Installed $BAR_PLUGIN_ID -> $BAR_DEST_DIR"
+install_full_bar
 
 if omarchy-shell shell rescanPlugins; then
     echo "Omarchy shell rescanned plugins."

--- a/scripts/test-install-command.sh
+++ b/scripts/test-install-command.sh
@@ -44,6 +44,10 @@ USER_THEME_SET="$XDG_BIN_HOME/omagen-theme-set"
   printf 'full-bar manifest was not installed\n' >&2
   exit 1
 }
+[[ -f "$XDG_CONFIG_HOME/omarchy/plugins/pretty.omagen.bar/qml/services/BoundedOutputParser.qml" ]] || {
+  printf 'full-bar QML service dependency was not installed\n' >&2
+  exit 1
+}
 [[ "$(sed -n '1,2p' "$USER_THEME_SET")" == $'#!/usr/bin/env bash\n# Omagen user-facing theme activation adapter' ]] || {
   printf 'user dispatcher ownership marker missing\n' >&2
   exit 1

--- a/scripts/test-install-command.sh
+++ b/scripts/test-install-command.sh
@@ -53,6 +53,34 @@ USER_THEME_SET="$XDG_BIN_HOME/omagen-theme-set"
   exit 1
 }
 
+# Production starts with the plugin manager's clone as the overlay package.
+# Verify that the documented in-place bar refresh uses that clone as a source
+# without copying the overlay package onto itself or deleting its files.
+PRODUCTION_HOME="$TMP_DIR/production-home"
+PRODUCTION_CONFIG="$PRODUCTION_HOME/.config"
+PRODUCTION_PLUGIN="$PRODUCTION_CONFIG/omarchy/plugins/pretty.omagen"
+mkdir -p "$PRODUCTION_PLUGIN"
+cp -a "$ROOT_DIR/." "$PRODUCTION_PLUGIN/"
+HOME="$PRODUCTION_HOME" \
+XDG_CONFIG_HOME="$PRODUCTION_CONFIG" \
+XDG_STATE_HOME="$PRODUCTION_HOME/.local/state" \
+XDG_CACHE_HOME="$PRODUCTION_HOME/.cache" \
+XDG_BIN_HOME="$PRODUCTION_HOME/.local/bin" \
+OMARCHY_PATH="$OMARCHY_PATH" \
+"$PRODUCTION_PLUGIN/install.sh" --bar-only >/dev/null
+[[ -f "$PRODUCTION_PLUGIN/manifest.json" ]] || {
+  printf 'bar-only production refresh modified the overlay package\n' >&2
+  exit 1
+}
+[[ -f "$PRODUCTION_CONFIG/omarchy/plugins/pretty.omagen.bar/manifest.json" ]] || {
+  printf 'bar-only production refresh did not install the full-bar manifest\n' >&2
+  exit 1
+}
+[[ -f "$PRODUCTION_CONFIG/omarchy/plugins/pretty.omagen.bar/qml/services/BoundedOutputParser.qml" ]] || {
+  printf 'bar-only production refresh did not install the full-bar QML service dependency\n' >&2
+  exit 1
+}
+
 printf 'user-owned command\n' >"$USER_THEME_SET"
 run_install
 [[ "$(<"$USER_THEME_SET")" == 'user-owned command' ]] || {


### PR DESCRIPTION
## Summary
- make the one-repository production install materialize both Omagen plugin packages
- include the full-bar QML service dependency required by `CustomCommandModule.qml`
- keep the native Omarchy bar active until Test Live explicitly selects a full-bar preset

## Validation
- `GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh`
- `scripts/test-install-command.sh`

This is the first promotion step from `nightly`; after merge, promote `nightly` into `dev` and then `dev` into `main`.