### PR TITLE
Promote v2.0.1 product snapshot to main

### DIFF
--- a/.github/release-provenance.json
+++ b/.github/release-provenance.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "policyVersion": "product-docs-projection-v1",
+  "sourceBranch": "dev",
+  "sourceSha": "0e20bf839652bbf09c7529178153ac8248a20bd2",
+  "releaseVersion": "v2.0.1",
+  "generatedFiles": [
+    "README.md"
+  ],
+  "generatedAt": "2026-09-10T18:21:27.127440Z"
+}

--- a/README.md
+++ b/README.md
@@ -1,99 +1,206 @@
-# Omagen development branch
+<!-- omagen-product-readme: canonical-source -->
+![Omagen wordmark](docs/product/assets/branding/omagen-wordmark.png)
 
-This checkout is the `nightly` branch, intended for contributors and testers.
-It may contain incomplete or experimental work and must not be used as the
-normal user installation source. The controlled promotion path is:
+<div align="center">
 
-```text
-nightly → dev → main → marketplace verification
-```
+# Omagen
 
-The `dev` branch is the protected integration and release-candidate branch.
-The `main` branch owns the stable product README, demos, screenshots, user
-installation, upgrade, recovery, and release notes. See the [stable product
-README](https://github.com/prettyletto/omagen/blob/main/README.md) for the
-user-facing experience.
+**Turn an image into an Omarchy desktop that feels like yours.**
 
-## Contributor setup
+Generate a complete theme, explore meaningful variations, preview the result
+without committing to it, and apply it safely when it feels right.
 
-Omagen is an Omarchy Quattro plugin composed of two separately owned packages:
+[![Build](https://img.shields.io/github/actions/workflow/status/prettyletto/omagen/verify-bundled-backend.yml?branch=main&style=flat-square&label=build)](https://github.com/prettyletto/omagen/actions)
+[![Documentation](https://img.shields.io/badge/docs-product%20guide-5b8def?style=flat-square)](docs/product/README.md)
+[![License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](LICENSE)
 
-- `pretty.omagen` — the overlay and launcher/status widget.
-- `pretty.omagen.bar` — the optional full-bar plugin.
+[Get started](#get-started) · [See the workflow](#the-omagen-workflow) · [Browse examples](docs/product/examples/README.md) · [Read the product docs](#product-documentation)
 
-Runtime requirements are Omarchy Quattro, Hyprland, Quickshell, and Linux
-x86_64 for the bundled backend executable. Demo applications are optional and
-are resolved with fallbacks. The plugin is unsandboxed and can modify the
-user-level themes, settings, shell state, backgrounds, and Omagen-owned
-session resources described in the [architecture](docs/architecture/README.md).
-It does not require `sudo`, install system packages, or configure privileged
-services.
+</div>
 
-Clone the repository and install the current checkout locally:
+![Omagen workflow preview](docs/product/assets/demos/omagen-demo-v2.gif)
+
+## Get started
+
+Omagen is built for Omarchy Quattro with Hyprland and Quickshell on Linux
+x86_64. Install the stable repository through Omarchy's plugin manager, then
+run the bundled package installer once so the same repository materializes both
+Omagen plugin packages:
 
 ```zsh
-git clone https://github.com/prettyletto/omagen.git
-cd omagen
-./dev-install.sh
+omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only
 ```
 
-For tester or release-candidate validation, inspect an immutable full commit
-before installing it. The bootstrap refuses a mutable branch head:
+The first command installs and enables the Studio overlay. Omarchy's plugin
+manager validates only the repository's root manifest, so the second command
+also installs the separate `pretty.omagen.bar` package from the same checkout.
+It does not select that bar; the native Quattro bar remains active until you
+choose a full-bar preset in Omagen. The checked-in backend is used, so Go is not
+required.
 
-```zsh
-git clone https://github.com/prettyletto/omagen.git /tmp/omagen-review
-cd /tmp/omagen-review
-git show --stat --oneline <full-40-character-commit-sha>
-OMAGEN_TEST_BRANCH=nightly \
-OMAGEN_TEST_COMMIT=<full-40-character-commit-sha> \
-  ./scripts/install-branch.sh
-```
+After updating the plugin with `omarchy plugin update pretty.omagen --yes`,
+run `"$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only`
+again to synchronize the full-bar package.
 
-Run the local repository gate from zsh:
+Then open Omagen from the Omarchy launcher, choose a local image, review a
+palette direction, and use **Preview** or **Demo** before selecting **Apply**.
+The [getting started guide](docs/product/getting-started.md) covers requirements, first
+launch, optional applications, and removal.
 
-```zsh
-GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh
-python3 scripts/marketplace-preflight.py \
-  --commit "$(git rev-parse HEAD)" \
-  --report /tmp/omagen-marketplace-report.json
-```
+To remove the packages later:
 
-The preflight is deterministic, read-only, and never executes plugin code or
-downloaded content. It scans both manifests source-wide, checks the root
-packaging contract, records capabilities and findings against the exact commit,
-and returns `passed`, `review-required`, or `needs-fixes`.
-
-## Developer documentation
-
-- [Development guide](docs/development.md) — local setup, tests, packaging,
-  QML validation, and the repository gate.
-- [Release and promotion process](docs/development/release-process.md) —
-  branch contracts, candidate states, exact-commit evidence, and marketplace
-  submission.
-- [Architecture](docs/architecture/README.md) — plugin boundaries, the
-  QML/backend contract, generation, lifecycle, and recovery ownership.
-- [Demo workspace](docs/demo.md) — implementation and ownership contracts for
-  the temporary Demo paths.
-- [Contributing](CONTRIBUTING.md) — pull requests, reviews, and validation
-  expectations.
-- [Security policy](SECURITY.md) — trust boundaries and vulnerability reports.
-
-## Removal during development
-
-From a local checkout, run:
-
-```zsh
-./uninstall.sh
-```
-
-The uninstaller recovers an active Omagen session and preserves permanent
-themes, unrelated plugins, and resources without Omagen ownership markers.
-For package-only removal, use the native plugin manager explicitly:
-
-```zsh
+```sh
 omarchy plugin remove pretty.omagen --yes
 omarchy plugin remove pretty.omagen.bar --yes
 ```
 
-The stable `main` branch must retain the user-facing installation and removal
-instructions in its own root README before the final release promotion.
+Removing the plugins does not delete permanent themes created by you. If an
+Omagen session is active, use its recovery or restore path before removing
+state manually.
+
+## What is Omagen?
+
+Omagen is an image-to-theme studio for [Omarchy Quattro](https://omarchy.org/).
+It turns the colors and atmosphere of a source image into a coherent desktop
+direction, then gives you a safe way to judge that direction before it becomes
+permanent.
+
+The experience is designed around a simple loop:
+
+```text
+image → palette directions → preview or Demo → apply or cancel
+```
+
+Omagen is one product suite with two technical plugin packages:
+
+- `pretty.omagen` provides the Studio overlay, image generation, previews,
+  Demo, lifecycle, recovery, and the launcher/status widget.
+- `pretty.omagen.bar` is the optional full-bar experience for users who want
+  Omagen's Bar presets and behavior as their active bar.
+
+They remain separate because Omarchy registers overlays/widgets and full bars
+as different plugin kinds. They are presented as one suite, but the full bar
+is explicit and opt-in so installing Omagen does not silently replace the
+native Quattro bar.
+
+## Why Omagen?
+
+- Start from an image you already like instead of tuning colors from scratch.
+- Compare six generated directions: Source, Calm, Mute, Deep, Vibrant, and
+  Balanced.
+- Preview Window, Shell, Bar, and Animation choices in context when you want
+  more than a palette.
+- Open a temporary Demo workspace to judge the theme across real desktop
+  surfaces.
+- Apply a named theme only when you are satisfied—or Cancel and leave the
+  current desktop unchanged.
+- Recover an interrupted session through the durable session record instead of
+  guessing which temporary files are safe to remove.
+
+## The Omagen workflow
+
+### 1. Choose an image
+
+Choose a local image in a common raster format. Omagen extracts representative
+colors and keeps the selected image as the visual source for the session.
+
+### 2. Explore directions
+
+Review six palette directions generated by the same production pipeline used by
+the applied theme. The gallery is meant to help you choose a mood, not just a
+single dominant color.
+
+### 3. Preview safely
+
+Use Live Canvas to inspect the staged result. Use **Test live** for a reversible
+desktop preview, or open **Demo** to see the composition across a temporary
+editor, terminal, system monitor, and file manager workspace.
+
+### 4. Apply or cancel
+
+**Apply** writes a named permanent theme after the staged session is ready.
+**Cancel** restores the original theme, background, and Omagen-owned temporary
+resources. **Quit** uses the same recovery path when a session is active.
+
+### 5. Recover when interrupted
+
+If Omagen or the shell is interrupted during a preview or Apply, the next
+launch presents an explicit recovery choice. Restore the original desktop or
+resume the staged workspace when it can still be verified safely.
+
+## See it in action
+
+[![Watch the Omagen walkthrough](docs/product/assets/social/omagen-walkthrough-thumbnail-v2.png)](https://youtu.be/juDJe0zWwZI)
+
+Watch the [full Omagen walkthrough on YouTube](https://youtu.be/juDJe0zWwZI)
+for the image-to-theme flow, preview paths, Demo, and Apply experience.
+
+## Bar examples
+
+Here are a few examples of the optional Omagen bar direction across different
+placements and information densities. The full bar is an opt-in part of the
+Omagen suite; installing the core Studio does not silently replace Omarchy's
+native bar.
+
+<p align="center">
+  <img src="docs/product/assets/screenshots/bar-examples/bar-01-left-wide.png" width="850" alt="Wide bar placed toward the left">
+</p>
+<p align="center">
+  <img src="docs/product/assets/screenshots/bar-examples/bar-02-split-wide.png" width="850" alt="Wide split bar layout">
+</p>
+
+See the [full bar example gallery](docs/product/assets/screenshots/bar-examples/README.md)
+for all seven layouts, placement variants, and capture notes.
+
+## New v2 examples
+
+The v2 gallery pairs each generated theme's source background with its clean
+desktop preview. These examples show the range of compositions Omagen can
+produce from very different images.
+
+| Theme | Source background | Generated preview |
+| --- | --- | --- |
+| Elastic Example | <img src="assets/examples/v2/elastic-example-background.webp" alt="Elastic Example source background" width="300"> | <img src="assets/examples/v2/elastic-example-preview.webp" alt="Elastic Example generated preview" width="300"> |
+| Gothic Example | <img src="assets/examples/v2/gothic-example-background.webp" alt="Gothic Example source background" width="300"> | <img src="assets/examples/v2/gothic-example-preview.webp" alt="Gothic Example generated preview" width="300"> |
+| Japan Example | <img src="assets/examples/v2/japan-example-background.webp" alt="Japan Example source background" width="300"> | <img src="assets/examples/v2/japan-example-preview.webp" alt="Japan Example generated preview" width="300"> |
+| Nature Example | <img src="assets/examples/v2/nature-example-background.webp" alt="Nature Example source background" width="300"> | <img src="assets/examples/v2/nature-example-preview.webp" alt="Nature Example generated preview" width="300"> |
+| Retro Example | <img src="assets/examples/v2/retro-example-background.webp" alt="Retro Example source background" width="300"> | <img src="assets/examples/v2/retro-example-preview.webp" alt="Retro Example generated preview" width="300"> |
+
+See the [complete v2 example gallery](docs/product/examples/README.md), including the
+historical examples explicitly labeled **made with Omagen v1**.
+
+## Product documentation
+
+| Guide | What it covers |
+| --- | --- |
+| [Getting started](docs/product/getting-started.md) | Installation, first launch, and the shortest path to a theme. |
+| [Product workflow](docs/product/workflow.md) | Preview, Test live, Demo, Apply, Cancel, and Quit. |
+| [Capabilities and trust](docs/product/capabilities.md) | What Omagen can read, write, invoke, and preserve. |
+| [Recovery and rollback](docs/product/recovery.md) | Interrupted sessions, restoration, ownership, and safe removal. |
+| [Examples](docs/product/examples/README.md) | Curated v2 wallpaper/theme pairs and example metadata. |
+| [Demo materials](docs/product/demos/README.md) | Product walkthroughs and the capture plan for v2. |
+| [Asset catalog](docs/product/assets/README.md) | Screenshots, recordings, examples, and provenance notes. |
+| [Asset checklist](docs/product/ASSET-CHECKLIST.md) | Evidence still required before stable release. |
+| [v2.0.0 release notes](docs/product/release-notes/v2.0.0.md) | Release scope, upgrade notes, limitations, and verification status. |
+
+For implementation contracts, contributor setup, compatibility evidence, and
+maintainer release procedures, use the [developer documentation](docs/README.md)
+and [release process](docs/development/release-process.md).
+
+## Trust boundary and capabilities
+
+Omagen is unsandboxed user-level plugin code. It can read the image and Omarchy
+configuration you select, write generated themes and Omagen-owned session
+state, invoke its bundled backend and explicit user-level adapters, and
+interact with the current Omarchy/Hyprland session.
+
+It does not require `sudo`, install system packages, or configure privileged
+services. It does not own unrelated themes, shell configuration, backgrounds,
+plugins, or user files. Read the [capabilities and trust guide](docs/product/capabilities.md)
+before installing if you want the complete boundary.
+
+The marketplace preflight is a release gate and exact-commit evidence; it is
+not a security certification, endorsement, or guarantee. See the developer
+[security policy](SECURITY.md) and [release process](docs/development/release-process.md)
+for the maintainer-level details.

--- a/docs/architecture/product-boundaries.md
+++ b/docs/architecture/product-boundaries.md
@@ -26,6 +26,7 @@ Omarchy, and the runtime adapters meet through explicit data/protocol seams.
   assets, and the `bar/BarSizing.js` helper used by the overlay.
 - `~/.config/omarchy/plugins/pretty.omagen.bar/` contains the full-Bar entry
   point, Bar host files, `bar/` presets/widgets, the maintained Quattro clone,
-  and compiled shader assets.
+  its bounded `qml/services/BoundedOutputParser.qml` dependency, and compiled
+  shader assets.
 
 Neither manifest may absorb the other product's entry point or ownership.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -35,7 +35,7 @@ Omagen plugin packages:
 
 ```zsh
 omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
-  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only
 ```
 
 The first command installs and enables the Studio overlay. Omarchy's plugin
@@ -46,7 +46,8 @@ choose a full-bar preset in Omagen. The checked-in backend is used, so Go is not
 required.
 
 After updating the plugin with `omarchy plugin update pretty.omagen --yes`,
-run the installer command again to synchronize the full-bar package.
+run `"$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only`
+again to synchronize the full-bar package.
 
 Then open Omagen from the Omarchy launcher, choose a local image, review a
 palette direction, and use **Preview** or **Demo** before selecting **Apply**.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -29,11 +29,24 @@ without committing to it, and apply it safely when it feels right.
 ## Get started
 
 Omagen is built for Omarchy Quattro with Hyprland and Quickshell on Linux
-x86_64. Install the stable repository through Omarchy's plugin manager:
+x86_64. Install the stable repository through Omarchy's plugin manager, then
+run the bundled package installer once so the same repository materializes both
+Omagen plugin packages:
 
-```sh
-omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes
+```zsh
+omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
 ```
+
+The first command installs and enables the Studio overlay. Omarchy's plugin
+manager validates only the repository's root manifest, so the second command
+also installs the separate `pretty.omagen.bar` package from the same checkout.
+It does not select that bar; the native Quattro bar remains active until you
+choose a full-bar preset in Omagen. The checked-in backend is used, so Go is not
+required.
+
+After updating the plugin with `omarchy plugin update pretty.omagen --yes`,
+run the installer command again to synchronize the full-bar package.
 
 Then open Omagen from the Omarchy launcher, choose a local image, review a
 palette direction, and use **Preview** or **Demo** before selecting **Apply**.

--- a/docs/product/getting-started.md
+++ b/docs/product/getting-started.md
@@ -17,15 +17,22 @@ fallback is selected instead.
 
 ## Install
 
-Install the stable repository with Omarchy's plugin manager:
+Install the stable repository with Omarchy's plugin manager, then run the
+bundled package installer once:
 
-```sh
-omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes
+```zsh
+omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
 ```
 
-This installs the Omagen suite without requiring Go. The core overlay and the
-optional full-bar package remain separate in Omarchy's registry so the native
-Quattro bar is not replaced unexpectedly.
+The plugin manager installs the repository's root `pretty.omagen` package. The
+second command installs the separate `pretty.omagen.bar` package from the same
+repository checkout. This uses the checked-in backend, so Go is not required.
+The full-bar package is installed but not selected; the native Quattro bar
+remains active until you choose a full-bar preset in Omagen.
+
+After updating the plugin with `omarchy plugin update pretty.omagen --yes`, run
+the installer command again to synchronize the full-bar package.
 
 ## First launch
 

--- a/docs/product/getting-started.md
+++ b/docs/product/getting-started.md
@@ -22,7 +22,7 @@ bundled package installer once:
 
 ```zsh
 omarchy plugin add https://github.com/prettyletto/omagen.git --enable --yes && \
-  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --skip-build
+  "$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only
 ```
 
 The plugin manager installs the repository's root `pretty.omagen` package. The
@@ -32,7 +32,8 @@ The full-bar package is installed but not selected; the native Quattro bar
 remains active until you choose a full-bar preset in Omagen.
 
 After updating the plugin with `omarchy plugin update pretty.omagen --yes`, run
-the installer command again to synchronize the full-bar package.
+`"$HOME/.config/omarchy/plugins/pretty.omagen/install.sh" --bar-only` again to
+synchronize the full-bar package.
 
 ## First launch
 

--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,8 @@ for destination in \
     "$BAR_DEST_DIR/NativeBarClone.qml" \
     "$BAR_DEST_DIR/WorkspacePresentation.qml" \
     "$BAR_DEST_DIR/BarModel.js" \
+    "$BAR_DEST_DIR/qml" \
+    "$BAR_DEST_DIR/qml/services" \
     "$BAR_DEST_DIR/glitch.frag.qsb" \
     "$BAR_DEST_DIR/glitch.vert.qsb"; do
     if [[ -L "$destination" ]]; then
@@ -172,6 +174,14 @@ cp "$SRC_DIR/WorkspacePresentation.qml" "$BAR_DEST_DIR/WorkspacePresentation.qml
 cp "$SRC_DIR/BarModel.js" "$BAR_DEST_DIR/BarModel.js"
 rm -rf "$BAR_DEST_DIR/bar"
 cp -a "$SRC_DIR/bar" "$BAR_DEST_DIR/bar"
+# The full-bar plugin is installed independently from pretty.omagen, so it
+# must carry the service used by NativeBarClone and bar/CustomCommandModule.
+# Keep the payload minimal rather than merging the overlay's qml tree or
+# manifests.
+rm -rf "$BAR_DEST_DIR/qml"
+mkdir -p "$BAR_DEST_DIR/qml/services"
+cp "$SRC_DIR/qml/services/BoundedOutputParser.qml" \
+    "$BAR_DEST_DIR/qml/services/BoundedOutputParser.qml"
 cp "$SRC_DIR/qml/components/glitch.frag.qsb" "$BAR_DEST_DIR/glitch.frag.qsb"
 cp "$SRC_DIR/qml/components/glitch.vert.qsb" "$BAR_DEST_DIR/glitch.vert.qsb"
 

--- a/install.sh
+++ b/install.sh
@@ -23,22 +23,93 @@ done
 
 usage() {
     cat <<EOF
-Usage: $0 [--skip-build]
+Usage: $0 [--skip-build|--bar-only]
 
 Options:
   --skip-build  Install the checked-in backend binary without compiling Go.
+  --bar-only    Install or refresh only the separate full-bar package.
 EOF
 }
 
 BUILD_BACKEND=1
+BAR_ONLY=0
 
 for arg in "$@"; do
     case "$arg" in
         -h|--help) usage; exit 0 ;;
         --skip-build) BUILD_BACKEND=0 ;;
+        --bar-only) BAR_ONLY=1; BUILD_BACKEND=0 ;;
         *) usage >&2; exit 2 ;;
     esac
 done
+
+install_full_bar() {
+    if [[ "$SRC_DIR" == "$BAR_DEST_DIR" ]]; then
+        echo "Refusing to install the full bar from its own destination: $SRC_DIR" >&2
+        return 1
+    fi
+
+    # The full bar is a separate plugin kind. Keeping it separate from the
+    # bar-widget manifest is required by Quattro's registry: a manifest
+    # selected as the active bar is not also treated as a layout widget.
+    echo "Installing $BAR_PLUGIN_ID..."
+    if [[ -L "$BAR_DEST_DIR" ]]; then
+        echo "Refusing to install through symlinked plugin directory: $BAR_DEST_DIR" >&2
+        return 1
+    fi
+    mkdir -p "$BAR_DEST_DIR"
+    for destination in \
+        "$BAR_DEST_DIR/manifest.json" \
+        "$BAR_DEST_DIR/OmagenBar.qml" \
+        "$BAR_DEST_DIR/BarSurface.qml" \
+        "$BAR_DEST_DIR/BarMoveGhostPanel.qml" \
+        "$BAR_DEST_DIR/CyberpunkBarSignal.qml" \
+        "$BAR_DEST_DIR/NativeBarClone.qml" \
+        "$BAR_DEST_DIR/WorkspacePresentation.qml" \
+        "$BAR_DEST_DIR/BarModel.js" \
+        "$BAR_DEST_DIR/qml" \
+        "$BAR_DEST_DIR/qml/services" \
+        "$BAR_DEST_DIR/glitch.frag.qsb" \
+        "$BAR_DEST_DIR/glitch.vert.qsb"; do
+        if [[ -L "$destination" ]]; then
+            echo "Refusing to install through symlinked package path: $destination" >&2
+            return 1
+        fi
+    done
+    cp "$SRC_DIR/bar-manifest.json" "$BAR_DEST_DIR/manifest.json"
+    cp "$SRC_DIR/OmagenBar.qml" "$BAR_DEST_DIR/OmagenBar.qml"
+    cp "$SRC_DIR/BarSurface.qml" "$BAR_DEST_DIR/BarSurface.qml"
+    cp "$SRC_DIR/BarMoveGhostPanel.qml" "$BAR_DEST_DIR/BarMoveGhostPanel.qml"
+    cp "$SRC_DIR/CyberpunkBarSignal.qml" "$BAR_DEST_DIR/CyberpunkBarSignal.qml"
+    cp "$SRC_DIR/NativeBarClone.qml" "$BAR_DEST_DIR/NativeBarClone.qml"
+    cp "$SRC_DIR/WorkspacePresentation.qml" "$BAR_DEST_DIR/WorkspacePresentation.qml"
+    cp "$SRC_DIR/BarModel.js" "$BAR_DEST_DIR/BarModel.js"
+    rm -rf "$BAR_DEST_DIR/bar"
+    cp -a "$SRC_DIR/bar" "$BAR_DEST_DIR/bar"
+    # The full-bar plugin is installed independently from pretty.omagen, so it
+    # must carry the service used by NativeBarClone and bar/CustomCommandModule.
+    # Keep the payload minimal rather than merging the overlay's qml tree or
+    # manifests.
+    rm -rf "$BAR_DEST_DIR/qml"
+    mkdir -p "$BAR_DEST_DIR/qml/services"
+    cp "$SRC_DIR/qml/services/BoundedOutputParser.qml" \
+        "$BAR_DEST_DIR/qml/services/BoundedOutputParser.qml"
+    cp "$SRC_DIR/qml/components/glitch.frag.qsb" "$BAR_DEST_DIR/glitch.frag.qsb"
+    cp "$SRC_DIR/qml/components/glitch.vert.qsb" "$BAR_DEST_DIR/glitch.vert.qsb"
+
+    echo "Installed $BAR_PLUGIN_ID -> $BAR_DEST_DIR"
+}
+
+if ((BAR_ONLY)); then
+    install_full_bar
+    if omarchy-shell shell rescanPlugins; then
+        echo "Omarchy shell rescanned plugins."
+    else
+        echo "Omarchy shell is not running; rescan later with:"
+        echo "  omarchy-shell shell rescanPlugins"
+    fi
+    exit 0
+fi
 
 if ((BUILD_BACKEND)); then
     echo "Building Omagen backend..."
@@ -50,6 +121,12 @@ else
         exit 1
     }
     echo "Using checked-in Omagen backend (Go build skipped)."
+fi
+
+if [[ "$SRC_DIR" == "$DEST_DIR" ]]; then
+    echo "Refusing a full install from the installed overlay directory: $SRC_DIR" >&2
+    echo "Run this installer from an external checkout, or use --bar-only to refresh the full bar." >&2
+    exit 1
 fi
 
 echo "Installing Omagen..."
@@ -137,56 +214,8 @@ else
     echo "Installed user command: $USER_THEME_SET"
 fi
 
-# The full bar is a separate plugin kind. Keeping it separate from the
-# bar-widget manifest is required by Quattro's registry: a manifest selected
-# as the active bar is not also treated as a layout widget.
-echo "Installing $BAR_PLUGIN_ID..."
-if [[ -L "$BAR_DEST_DIR" ]]; then
-    echo "Refusing to install through symlinked plugin directory: $BAR_DEST_DIR" >&2
-    exit 1
-fi
-mkdir -p "$BAR_DEST_DIR"
-for destination in \
-    "$BAR_DEST_DIR/manifest.json" \
-    "$BAR_DEST_DIR/OmagenBar.qml" \
-    "$BAR_DEST_DIR/BarSurface.qml" \
-    "$BAR_DEST_DIR/BarMoveGhostPanel.qml" \
-    "$BAR_DEST_DIR/CyberpunkBarSignal.qml" \
-    "$BAR_DEST_DIR/NativeBarClone.qml" \
-    "$BAR_DEST_DIR/WorkspacePresentation.qml" \
-    "$BAR_DEST_DIR/BarModel.js" \
-    "$BAR_DEST_DIR/qml" \
-    "$BAR_DEST_DIR/qml/services" \
-    "$BAR_DEST_DIR/glitch.frag.qsb" \
-    "$BAR_DEST_DIR/glitch.vert.qsb"; do
-    if [[ -L "$destination" ]]; then
-        echo "Refusing to install through symlinked package path: $destination" >&2
-        exit 1
-    fi
-done
-cp "$SRC_DIR/bar-manifest.json" "$BAR_DEST_DIR/manifest.json"
-cp "$SRC_DIR/OmagenBar.qml" "$BAR_DEST_DIR/OmagenBar.qml"
-cp "$SRC_DIR/BarSurface.qml" "$BAR_DEST_DIR/BarSurface.qml"
-cp "$SRC_DIR/BarMoveGhostPanel.qml" "$BAR_DEST_DIR/BarMoveGhostPanel.qml"
-cp "$SRC_DIR/CyberpunkBarSignal.qml" "$BAR_DEST_DIR/CyberpunkBarSignal.qml"
-cp "$SRC_DIR/NativeBarClone.qml" "$BAR_DEST_DIR/NativeBarClone.qml"
-cp "$SRC_DIR/WorkspacePresentation.qml" "$BAR_DEST_DIR/WorkspacePresentation.qml"
-cp "$SRC_DIR/BarModel.js" "$BAR_DEST_DIR/BarModel.js"
-rm -rf "$BAR_DEST_DIR/bar"
-cp -a "$SRC_DIR/bar" "$BAR_DEST_DIR/bar"
-# The full-bar plugin is installed independently from pretty.omagen, so it
-# must carry the service used by NativeBarClone and bar/CustomCommandModule.
-# Keep the payload minimal rather than merging the overlay's qml tree or
-# manifests.
-rm -rf "$BAR_DEST_DIR/qml"
-mkdir -p "$BAR_DEST_DIR/qml/services"
-cp "$SRC_DIR/qml/services/BoundedOutputParser.qml" \
-    "$BAR_DEST_DIR/qml/services/BoundedOutputParser.qml"
-cp "$SRC_DIR/qml/components/glitch.frag.qsb" "$BAR_DEST_DIR/glitch.frag.qsb"
-cp "$SRC_DIR/qml/components/glitch.vert.qsb" "$BAR_DEST_DIR/glitch.vert.qsb"
-
 echo "Installed $PLUGIN_ID -> $DEST_DIR"
-echo "Installed $BAR_PLUGIN_ID -> $BAR_DEST_DIR"
+install_full_bar
 
 if omarchy-shell shell rescanPlugins; then
     echo "Omarchy shell rescanned plugins."

--- a/scripts/test-install-command.sh
+++ b/scripts/test-install-command.sh
@@ -44,6 +44,10 @@ USER_THEME_SET="$XDG_BIN_HOME/omagen-theme-set"
   printf 'full-bar manifest was not installed\n' >&2
   exit 1
 }
+[[ -f "$XDG_CONFIG_HOME/omarchy/plugins/pretty.omagen.bar/qml/services/BoundedOutputParser.qml" ]] || {
+  printf 'full-bar QML service dependency was not installed\n' >&2
+  exit 1
+}
 [[ "$(sed -n '1,2p' "$USER_THEME_SET")" == $'#!/usr/bin/env bash\n# Omagen user-facing theme activation adapter' ]] || {
   printf 'user dispatcher ownership marker missing\n' >&2
   exit 1

--- a/scripts/test-install-command.sh
+++ b/scripts/test-install-command.sh
@@ -53,6 +53,34 @@ USER_THEME_SET="$XDG_BIN_HOME/omagen-theme-set"
   exit 1
 }
 
+# Production starts with the plugin manager's clone as the overlay package.
+# Verify that the documented in-place bar refresh uses that clone as a source
+# without copying the overlay package onto itself or deleting its files.
+PRODUCTION_HOME="$TMP_DIR/production-home"
+PRODUCTION_CONFIG="$PRODUCTION_HOME/.config"
+PRODUCTION_PLUGIN="$PRODUCTION_CONFIG/omarchy/plugins/pretty.omagen"
+mkdir -p "$PRODUCTION_PLUGIN"
+cp -a "$ROOT_DIR/." "$PRODUCTION_PLUGIN/"
+HOME="$PRODUCTION_HOME" \
+XDG_CONFIG_HOME="$PRODUCTION_CONFIG" \
+XDG_STATE_HOME="$PRODUCTION_HOME/.local/state" \
+XDG_CACHE_HOME="$PRODUCTION_HOME/.cache" \
+XDG_BIN_HOME="$PRODUCTION_HOME/.local/bin" \
+OMARCHY_PATH="$OMARCHY_PATH" \
+"$PRODUCTION_PLUGIN/install.sh" --bar-only >/dev/null
+[[ -f "$PRODUCTION_PLUGIN/manifest.json" ]] || {
+  printf 'bar-only production refresh modified the overlay package\n' >&2
+  exit 1
+}
+[[ -f "$PRODUCTION_CONFIG/omarchy/plugins/pretty.omagen.bar/manifest.json" ]] || {
+  printf 'bar-only production refresh did not install the full-bar manifest\n' >&2
+  exit 1
+}
+[[ -f "$PRODUCTION_CONFIG/omarchy/plugins/pretty.omagen.bar/qml/services/BoundedOutputParser.qml" ]] || {
+  printf 'bar-only production refresh did not install the full-bar QML service dependency\n' >&2
+  exit 1
+}
+
 printf 'user-owned command\n' >"$USER_THEME_SET"
 run_install
 [[ "$(<"$USER_THEME_SET")" == 'user-owned command' ]] || {


### PR DESCRIPTION
## Controlled product promotion

This pull request was generated from the exact `dev` commit `0e20bf839652bbf09c7529178153ac8248a20bd2`.

It contains the complete validated `dev` product snapshot plus the generated stable root README and release provenance for `v2.0.1`. Review the full code and product documentation together.

The release workflow validated the source SHA, generated the release branch, projected the canonical product README, and recorded `.github/release-provenance.json`.

## Verification

- Release workflow source verification: passed.
- Product documentation projection and relative links: passed.
- Release branch contains the recorded `dev` source commit: passed.
- Local `GOCACHE=/tmp/omagen-gocache ./scripts/v1-check.sh`: passed on the promoted source snapshot.
- Marketplace preflight: `review-required`, findings 0.